### PR TITLE
chore: ignore .playwright-mcp and regenerate package-lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ extension/global_files/bootstrap.bundle.min.js*
 extension/global_files/bootstrap.min.css*
 extension/global_files/browser-polyfill.min.js*
 extension/global_files/jquery.slim.min.*
+/.playwright-mcp


### PR DESCRIPTION
## Summary
- Add `/.playwright-mcp` to `.gitignore` so the Playwright MCP scratch dir isn't tracked.
- Regenerate `package-lock.json` (dependency tree cleanup: removes redundant nested dev deps, bumps transitive versions). No `package.json` changes.

## Notes
- Lockfile remains `lockfileVersion: 2`.
- No source or runtime behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)