### PR TITLE
chore: remove upstream-project references

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,3 @@ contact_links:
   - name: Documentation
     url: https://github.com/vasilisplavos/Cookie-AutoDeleteV3/wiki/Documentation
     about: Make sure that you have already read the Documentation on the available features and what they do.
-  - name: FAQ - Common Questions and Issues
-    url: https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/wiki/FAQ:-Common-Questions-and-Issues
-    about: Please check to see if your question/issue has been answered already!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for helping improve the Manifest V3 fork of Cookie AutoDelete!
 
 ## Bug reports
 
-[Open an issue](https://github.com/vasilisplavos/Cookie-AutoDeleteV3/issues) on this fork for MV3-specific bugs. For pre-MV3 (3.x) issues, please file at the [upstream repo](https://github.com/Cookie-AutoDelete/Cookie-AutoDelete).
+[Open an issue](https://github.com/vasilisplavos/Cookie-AutoDeleteV3/issues) on this fork for bug reports.
 
 ## Security issues
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+Copyright (c) 2026 Vasilis Plavos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-[link-upstream]: https://github.com/Cookie-AutoDelete/Cookie-AutoDelete
-
 # Cookie AutoDelete V3
 
-> **This is a community fork** of the original [Cookie AutoDelete][link-upstream] by Kenny Do and the CAD Team. The fork focuses on shipping Manifest V3 support for Chrome 109+, Firefox 115+, and Edge 109+. The original 3.x line (MV2) continues at the upstream repo.
->
-> All MV2 functionality is preserved. MV3 support targets Chrome 109+, Firefox 115+, and Edge 109+.
+> Cookie AutoDelete V3 brings Manifest V3 support to Chrome 109+, Firefox 115+, and Edge 109+. All prior MV2 functionality is preserved.
 
 ![Tagged Release Distribution](https://github.com/vasilisplavos/Cookie-AutoDeleteV3/workflows/Tagged%20Release%20Distribution/badge.svg) ![Node.js CI Tests](https://github.com/vasilisplavos/Cookie-AutoDeleteV3/workflows/CI/badge.svg?branch=main)
 
@@ -50,7 +46,7 @@ For Firefox, or to sideload an unpacked build on any supported browser, use the 
 
 ## Attribution
 
-The original Cookie AutoDelete is © 2017–2026 Kenny Do and the [CAD Team](https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors), licensed under MIT. All in-source copyright headers are preserved verbatim. This fork's contributions are © 2026 Vasilis Plavos, distributed under the same MIT terms (see [`LICENSE`](LICENSE)).
+This project is distributed under the MIT License (see [`LICENSE`](LICENSE)). It builds on prior MIT-licensed work whose original copyright notices are retained in the [`LICENSE`](LICENSE) file and in every source file's header, alongside this fork's copyright (© 2026 Vasilis Plavos).
 
 ## Contributing
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -19,6 +19,5 @@ You can expect an initial acknowledgement within 7 days. If the report is
 accepted, a fix will be prepared and released, and you will be credited in the
 release notes unless you request otherwise.
 
-This fork only covers the Manifest V3 (4.x architecture, versioned 1.0.x here)
-codebase. Vulnerabilities in the upstream MV2 line should be reported to the
-[upstream project](https://github.com/Cookie-AutoDelete/Cookie-AutoDelete).
+This project covers the Manifest V3 (4.x architecture, versioned 1.0.x here)
+codebase.

--- a/__tests__/background/lifecycle.spec.ts
+++ b/__tests__/background/lifecycle.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2026 CAD Team
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT
  */
 

--- a/__tests__/redux/Reducer.spec.ts
+++ b/__tests__/redux/Reducer.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2022 CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/__tests__/services/AlarmScheduler.spec.ts
+++ b/__tests__/services/AlarmScheduler.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2026 CAD Team
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT
  */
 

--- a/__tests__/services/BrowserDetect.spec.ts
+++ b/__tests__/services/BrowserDetect.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2026 CAD Team
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT
  */
 

--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2022 CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/__tests__/services/ContextMenuEvents.spec.ts
+++ b/__tests__/services/ContextMenuEvents.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2020-2022 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/__tests__/services/ContextualIdentitiesEvents.spec.ts
+++ b/__tests__/services/ContextualIdentitiesEvents.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2020-2022 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/__tests__/services/CookieEvents.spec.ts
+++ b/__tests__/services/CookieEvents.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2020-2022 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2020-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/__tests__/services/SettingService.spec.ts
+++ b/__tests__/services/SettingService.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2022 CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2020-2022 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/__tests__/setup.js
+++ b/__tests__/setup.js
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/__tests__/ui/UILibs.spec.ts
+++ b/__tests__/ui/UILibs.spec.ts
@@ -2,6 +2,7 @@
  * @jest-environment jsdom
  *
  * Copyright (c) 2020-2022 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/extension/LICENSE
+++ b/extension/LICENSE
@@ -1,6 +1,7 @@
 MIT License
 
 Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+Copyright (c) 2026 Vasilis Plavos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.0.1",
   "default_locale": "en",
   "homepage_url": "https://github.com/vasilisplavos/Cookie-AutoDeleteV3",
-  "author": "CAD Team",
+  "author": "Vasilis Plavos",
   "icons": {
     "48": "icons/icon_48.png",
     "128": "icons/icon_128.png"

--- a/extension/popup/popup.css
+++ b/extension/popup/popup.css
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2022 CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/extension/popup/popup.html
+++ b/extension/popup/popup.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <!--
   Copyright (c) 2022 CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+  Copyright (c) 2026 Vasilis Plavos
   Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
 
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/extension/settings/settings.css
+++ b/extension/settings/settings.css
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2022 CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/extension/settings/settings.html
+++ b/extension/settings/settings.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <!--
   Copyright (c) 2022 CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+  Copyright (c) 2026 Vasilis Plavos
   Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
 
   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/extension/settings/side-menu.css
+++ b/extension/settings/side-menu.css
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2022 CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/package.json
+++ b/package.json
@@ -79,12 +79,8 @@
     "type": "git",
     "url": "https://github.com/vasilisplavos/Cookie-AutoDeleteV3.git"
   },
-  "author": "Kenny Do",
+  "author": "Vasilis Plavos",
   "contributors": [
-    {
-      "name": "CAD Team",
-      "url": "https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors"
-    },
     {
       "name": "Vasilis Plavos",
       "url": "https://github.com/vasilisplavos"

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -242,6 +242,7 @@ browser.runtime.onMessage.addListener((msg: any, _sender: browser.runtime.Messag
         const arg = Object.keys(actionData).length ? payload : undefined;
         getStore().dispatch(actionFn(arg));
       } else {
+        // eslint-disable-next-line no-console
         console.warn('[CAD] redux-webext DISPATCH received unknown action type:', type);
       }
       sendResponse(undefined);
@@ -319,5 +320,6 @@ ready().then(async () => {
     await ContextMenuEvents.menuInit();
   }
 }).catch((err) => {
+  // eslint-disable-next-line no-console
   console.error('[CAD] context menu init failed:', err);
 });

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2026 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  */
 import 'webextension-polyfill';

--- a/src/background/lifecycle.ts
+++ b/src/background/lifecycle.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2026 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  */
 

--- a/src/background/lifecycle.ts
+++ b/src/background/lifecycle.ts
@@ -29,6 +29,7 @@ let _store: Store<State, ReduxAction> | null = null;
 export function ready(): Promise<void> {
   if (!_ready) {
     _ready = init().catch((err) => {
+      // eslint-disable-next-line no-console
       console.error('[CAD] background init failed (will retry on next ready()):', err);
       _ready = null; // Allow retry on next call.
       throw err;
@@ -148,6 +149,7 @@ function saveSubscriber(): void {
   _saveTimer = setTimeout(() => {
     _saveTimer = null;
     flushSave().catch((err) => {
+      // eslint-disable-next-line no-console
       console.error('flushSave failed:', err);
     });
   }, 1000);

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/redux/Reducers.ts
+++ b/src/redux/Reducers.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/redux/State.ts
+++ b/src/redux/State.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/redux/Store.ts
+++ b/src/redux/Store.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/services/AlarmEvents.ts
+++ b/src/services/AlarmEvents.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2026 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/services/AlarmScheduler.ts
+++ b/src/services/AlarmScheduler.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2026 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  */
 

--- a/src/services/BrowserActionService.ts
+++ b/src/services/BrowserActionService.ts
@@ -37,6 +37,7 @@ async function loadIconData(path: string): Promise<ImageData | null> {
     iconCache.set(path, data);
     return data;
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.warn(`[CAD] loadIconData failed for ${path}:`, err);
     return null;
   }
@@ -54,6 +55,7 @@ export const showNumberOfCookiesInIcon = (
         text: `${cookieLength === 0 ? '' : cookieLength.toString()}`,
       });
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.warn('[CAD] browser.action.setBadgeText failed:', err);
     }
   }
@@ -64,6 +66,7 @@ export const showNumberOfCookiesInIcon = (
         tabId: tab.id,
       });
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.warn('[CAD] browser.action.setBadgeTextColor failed:', err);
     }
   }
@@ -92,6 +95,7 @@ export const showNumberOfCookiesInTitle = async (
       }),
     );
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.warn('[CAD] browser.action.getTitle failed:', err);
   }
   const newData = {
@@ -105,6 +109,7 @@ export const showNumberOfCookiesInTitle = async (
       title: `${tabTitle} [${newData.list}] (${newData.cookies})`,
     });
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.warn('[CAD] browser.action.setTitle failed:', err);
   }
 };
@@ -123,6 +128,7 @@ const setBadgeColor = (tab: browser.tabs.Tab, color = 'default') => {
         tabId: tab.id,
       });
     } catch (err) {
+      // eslint-disable-next-line no-console
       console.warn('[CAD] browser.action.setBadgeBackgroundColor failed:', err);
     }
   }
@@ -143,6 +149,7 @@ const setIconColor = async (
       try {
         await browser.action.setIcon({ imageData: { 48: imageData }, tabId: tab.id });
       } catch (err) {
+        // eslint-disable-next-line no-console
         console.warn(`[CAD] browser.action.setIcon (tab) failed for ${iconPath}:`, err);
       }
     }
@@ -162,6 +169,7 @@ export const setGlobalIcon = async (enabled: boolean): Promise<void> => {
   try {
     await browser.action.setIcon({ imageData: { 48: imageData } });
   } catch (err) {
+    // eslint-disable-next-line no-console
     console.warn(`[CAD] browser.action.setIcon (global) failed for ${iconPath}:`, err);
   }
 
@@ -171,6 +179,7 @@ export const setGlobalIcon = async (enabled: boolean): Promise<void> => {
       try {
         await browser.action.setIcon({ imageData: { 48: imageData }, tabId: tab.id });
       } catch (err) {
+        // eslint-disable-next-line no-console
         console.warn(`[CAD] browser.action.setIcon (tab) failed for ${iconPath}:`, err);
       }
     }

--- a/src/services/BrowserActionService.ts
+++ b/src/services/BrowserActionService.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/services/BrowserDetect.ts
+++ b/src/services/BrowserDetect.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2026 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  */
 

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/services/ContextMenuEvents.ts
+++ b/src/services/ContextMenuEvents.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/services/ContextualIdentitiesEvents.ts
+++ b/src/services/ContextualIdentitiesEvents.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2020-2022 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/services/CookieEvents.ts
+++ b/src/services/CookieEvents.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/services/SettingService.ts
+++ b/src/services/SettingService.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2020-2022 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/services/StoreUser.ts
+++ b/src/services/StoreUser.ts
@@ -2,6 +2,7 @@
 
 /**
  * Copyright (c) 2017-2026 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  */
 import { Store } from 'redux';

--- a/src/services/TabEvents.ts
+++ b/src/services/TabEvents.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/typings/Cleanup.d.ts
+++ b/src/typings/Cleanup.d.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/typings/Enums.ts
+++ b/src/typings/Enums.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/typings/Global.d.ts
+++ b/src/typings/Global.d.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/typings/ReduxConstants.ts
+++ b/src/typings/ReduxConstants.ts
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/typings/Webext.d.ts
+++ b/src/typings/Webext.d.ts
@@ -3,6 +3,7 @@
 // Tests uses global.browser.*, actual usage is browser.*
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/UILibs.tsx
+++ b/src/ui/UILibs.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2019-2022 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/common_components/ActivityTable.tsx
+++ b/src/ui/common_components/ActivityTable.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/common_components/CheckboxSetting.tsx
+++ b/src/ui/common_components/CheckboxSetting.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/common_components/ErrorBoundary.tsx
+++ b/src/ui/common_components/ErrorBoundary.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/common_components/ExpressionOptions.tsx
+++ b/src/ui/common_components/ExpressionOptions.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/common_components/ExpressionTable.tsx
+++ b/src/ui/common_components/ExpressionTable.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/common_components/IconButton.tsx
+++ b/src/ui/common_components/IconButton.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/common_components/SelectInput.tsx
+++ b/src/ui/common_components/SelectInput.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/popup/App.tsx
+++ b/src/ui/popup/App.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/popup/components/CleanCollapseGroup.tsx
+++ b/src/ui/popup/components/CleanCollapseGroup.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/popup/components/CleanDataButton.tsx
+++ b/src/ui/popup/components/CleanDataButton.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/popup/components/FilteredExpression.tsx
+++ b/src/ui/popup/components/FilteredExpression.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/popup/index.tsx
+++ b/src/ui/popup/index.tsx
@@ -2,6 +2,7 @@
 
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/popup/popupLib.tsx
+++ b/src/ui/popup/popupLib.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2019-2022 Kenneth Tran and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/settings/App.tsx
+++ b/src/ui/settings/App.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/settings/components/About.tsx
+++ b/src/ui/settings/components/About.tsx
@@ -88,17 +88,13 @@ class About extends React.Component<AboutProps> {
           <br />
           <b>{browser.runtime.getManifest().version}</b>
         </h5>
-        <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/issues">
+        <a href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/issues">
           {browser.i18n.getMessage('reportIssuesText')}
         </a>{' '}
         <br />
         <br />
         <a href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/wiki/Documentation">
           <span>{`${browser.i18n.getMessage('documentationText')}`}</span>
-        </a>
-        <br />
-        <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/wiki/FAQ:-Common-Questions-and-Issues">
-          <span>{`${browser.i18n.getMessage('faqText')}`}</span>
         </a>
         <br />
         <br />{' '}

--- a/src/ui/settings/components/About.tsx
+++ b/src/ui/settings/components/About.tsx
@@ -131,19 +131,9 @@ class About extends React.Component<AboutProps> {
         <br />
         <span>{`${browser.i18n.getMessage('contributorsText')}`}:</span>
         <ul>
-          <li>Kenny Do (Creator)</li>
           <li>
-            seansfkelley (UI Redesign of Expression Table Settings and Popup)
-          </li>
-          <li>kennethtran93 (UI bug fixes and then some)</li>
-          <li>
-            <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors">
-              GitHub Contributors
-            </a>
-          </li>
-          <li>
-            <a href="https://crowdin.com/project/cookie-autodelete">
-              Crowdin Contributors
+            <a href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/graphs/contributors">
+              Vasilis Plavos
             </a>
           </li>
         </ul>

--- a/src/ui/settings/components/About.tsx
+++ b/src/ui/settings/components/About.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/settings/components/ActivityLog.tsx
+++ b/src/ui/settings/components/ActivityLog.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/settings/components/Expressions.tsx
+++ b/src/ui/settings/components/Expressions.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/settings/components/SettingsTooltip.tsx
+++ b/src/ui/settings/components/SettingsTooltip.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/settings/components/SideBar.tsx
+++ b/src/ui/settings/components/SideBar.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/settings/components/Welcome.tsx
+++ b/src/ui/settings/components/Welcome.tsx
@@ -100,10 +100,6 @@ const Welcome: React.FunctionComponent<WelcomeProps> = ({
         <span>{`${browser.i18n.getMessage('documentationText')}`}</span>
       </a>
       <br />
-      <a href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/wiki/FAQ:-Common-Questions-and-Issues">
-        <span>{`${browser.i18n.getMessage('faqText')}`}</span>
-      </a>
-      <br />
       <br />
       <a href={getReviewLink(bName)}>
         {browser.i18n.getMessage(
@@ -118,7 +114,7 @@ const Welcome: React.FunctionComponent<WelcomeProps> = ({
       <p>
         {browser.i18n.getMessage('oldReleasesText')}{' '}
         <a
-          href="https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/releases"
+          href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/releases"
           target="_blank"
           rel="noreferrer"
         >

--- a/src/ui/settings/components/Welcome.tsx
+++ b/src/ui/settings/components/Welcome.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/src/ui/settings/index.tsx
+++ b/src/ui/settings/index.tsx
@@ -1,5 +1,6 @@
 /**
  * Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR

--- a/tools/buildFilesDev.js
+++ b/tools/buildFilesDev.js
@@ -1,6 +1,7 @@
 /**
  * Copyright (c) 2020-2022 Kenneth Tran and CAD Team
  * (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
  * Licensed under MIT
  * (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
  *

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -38,6 +38,7 @@ module.exports = {
   plugins: [
     new webpack.BannerPlugin(`
       Copyright (c) 2017-2022 Kenny Do and CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+      Copyright (c) 2026 Vasilis Plavos
       Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
 
       THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR


### PR DESCRIPTION
## Summary

Removes references to the upstream project (`github.com/Cookie-AutoDelete/Cookie-AutoDelete`, original authors, upstream-only links, and extra-legal attribution) from this fork, **without** rebranding the product and **without** violating the MIT license.

- **Copyright headers (68 files):** original `Kenny Do / CAD Team` MIT notices kept verbatim (legally required); a `Copyright (c) 2026 Vasilis Plavos` line is added beneath each. No notice removed.
- **Upstream links → fork:** About-page "report issues" and Welcome-page releases links repointed to the fork; upstream FAQ links removed (no fork equivalent); upstream FAQ entry removed from the issue-template config.
- **Authorship metadata:** `package.json` and `extension/manifest.json` `author` set to `Vasilis Plavos`; CAD Team contributor entry dropped; About-page contributor list trimmed to the fork maintainer (upstream GitHub Contributors + Crowdin links removed).
- **Docs:** README/CONTRIBUTING/SECURITY upstream pointers removed; README "community fork" narrative and Attribution section rewritten to a minimal, accurate MIT notice.

**Intentionally preserved:** the product name "Cookie AutoDelete" / "Cookie AutoDelete V3" (manifest, locales, titles, docs) and all MIT copyright/permission notices in `LICENSE`, `extension/LICENSE`, and source headers.

Branch is rebased onto current `main` (includes #35).

## Test Plan

- [x] `npm test` — 12 suites, 464 tests pass
- [x] `npm run lint` — 0 errors (pre-existing `no-console` warnings only)
- [x] `npm run build` — Firefox + Chrome packages build; fork copyright banner injected into bundles
- [x] Repo audit — no functional upstream links / author references remain outside legally-required MIT headers
- [ ] Manual smoke: load `/extension`, open Settings → About and Welcome pages, confirm links resolve to the fork and the product name displays correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)