### PR TITLE
chore(ci): SHA-pin all GitHub Actions for supply-chain hardening (#47)

### DIFF
--- a/.github/workflows/ci_tag_release.yml
+++ b/.github/workflows/ci_tag_release.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.x'
       - name: Install Dependencies (npm ci)
@@ -35,13 +35,13 @@ jobs:
           echo "ffxpi=$(ls builds/*Firefox.xpi)" >> $GITHUB_OUTPUT
       - name: Archive Production Build Artifacts
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: builds
           path: builds
       - name: GitHub Releases
         id: github_releases
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_tag_testbuilds.yml
+++ b/.github/workflows/ci_tag_testbuilds.yml
@@ -12,9 +12,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Commit
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Use Node.js 22.x
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.x'
       - name: Install Dependencies (npm ci)
@@ -31,7 +31,7 @@ jobs:
           GITSHA: ${{ github.event.after }}
       - name: GitHub Releases
         id: github_releases
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,11 +40,11 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
         # Override language selection by uncommenting this and choosing your languages
         with:
           languages: ${{ matrix.language }}
@@ -52,7 +52,7 @@ jobs:
       # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below).
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
@@ -66,4 +66,4 @@ jobs:
       #     make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -19,15 +19,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - name: Use Node.js 22.x
         id: node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22.x'
       - name: Cache Node Modules
         id: nodeCache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
         with:
           # npm cache files stored in `~/.npm` on Linux
           path: ~/.npm
@@ -56,13 +56,13 @@ jobs:
         working-directory: ./builds
       - name: Upload Artifact for Mozilla Firefox Build
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.extbuilds.outputs.ffdir }}
           path: builds/${{ steps.extbuilds.outputs.ffdir }}
       - name: Upload Artifact for Google Chrome Build
         if: github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: ${{ steps.extbuilds.outputs.crdir }}
           path: builds/${{ steps.extbuilds.outputs.crdir }}


### PR DESCRIPTION
## Summary

Completes the optional **supply-chain hardening follow-up** from #47.

The core work of #47 (bumping `actions/checkout` v4 → v7) already landed via #42. This PR addresses the remaining item: replacing floating major-version tags with full commit SHAs across **all** four workflow files — not just `checkout`, but every action, since pinning only one while leaving the third-party `softprops/action-gh-release` floating would be inconsistent.

## Why

A floating tag like `@v7` can be silently re-pointed to malicious code if the action's upstream repository is compromised — a real, exploited supply-chain attack vector. A pinned commit SHA is immutable and cannot be moved.

## What changed

Every `uses:` reference is now SHA-pinned, with a `# vX.Y.Z` comment for readability. Each pin is at the action's **current major version — no behavior change**:

| Action | SHA | Comment |
|--------|-----|---------|
| `actions/checkout` | `9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0` | `# v7.0.0` |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | `# v4.4.0` |
| `actions/cache` | `0057852bfaa89a56745cba8c7296529d2fc39830` | `# v4.3.0` |
| `actions/upload-artifact` | `ea165f8d65b6e75b540449e92b4886f43607fa02` | `# v4.6.2` |
| `github/codeql-action/*` | `8aad20d150bbac5944a9f9d289da16a4b0d87c1e` | `# v4.36.2` |
| `softprops/action-gh-release` | `de2c0eb89ae2a093876385947365aca7b0e5f844` | `# v1` |

Files touched: `continuous-integration-workflow.yml`, `ci_tag_testbuilds.yml`, `ci_tag_release.yml`, `codeql-analysis.yml` (16 `uses:` references, 16 insertions / 16 deletions).

## No automation lost

Dependabot's `github-actions` ecosystem is already configured (daily) and **keeps SHA pins updated automatically** — it bumps the SHA and the `# vX.Y.Z` comment together.

## Note / out of scope

`softprops/action-gh-release` is pinned at its current **v1** (`de2c0eb`), which upstream has frozen — current is **v3**. Bumping it is a separate major-version decision with potential breaking changes (v2 dropped Node 16, changed inputs), so it's intentionally left for a dedicated Dependabot/manual PR.

## Verification

- ✅ All four YAML files parse correctly (job structure intact)
- ✅ Every SHA confirmed via the GitHub API to exist and match the stated version
- ✅ No floating `@v` tags remain (16/16 pinned)

Refs #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB92b3G3FSTnzkfvxAPyiA
