### PR TITLE
build(deps): bump softprops/action-gh-release from v1 to v3 (SHA-pinned)

### DIFF
--- a/.github/workflows/ci_tag_release.yml
+++ b/.github/workflows/ci_tag_release.yml
@@ -41,7 +41,7 @@ jobs:
           path: builds
       - name: GitHub Releases
         id: github_releases
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_tag_testbuilds.yml
+++ b/.github/workflows/ci_tag_testbuilds.yml
@@ -31,7 +31,7 @@ jobs:
           GITSHA: ${{ github.event.after }}
       - name: GitHub Releases
         id: github_releases
-        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
         if: startsWith(github.ref, 'refs/tags/')
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Follow-up to #48. That PR SHA-pinned every GitHub Action but deliberately kept `softprops/action-gh-release` at its **frozen v1** (`de2c0eb`), noting the major-version bump as a separate decision. This PR is that decision: bump **v1 → v3.0.1**, keeping the SHA pin.

## Why it's safe

`v1 → v3` is **purely a runtime change** — Node 16 → 20 (v2.0.0) → 24 (v3.0.0). No inputs or outputs changed across these majors.

The two release steps use only `files`, `body`, `draft`, `prerelease`, and the `GITHUB_TOKEN` env var. All of these are still declared in the v3 `action.yml` (verified against the pinned SHA). `ubuntu-latest` provides the Node 24 Actions runtime, so the v3.0.0 requirement is met.

## Change

```diff
- uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
+ uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
```

Applied in both `.github/workflows/ci_tag_release.yml` and `.github/workflows/ci_tag_testbuilds.yml` (2 insertions / 2 deletions).

## Verification

- ✅ Both YAML files parse (job structure intact)
- ✅ `718ea10…` confirmed via the GitHub API as the `v3` / `v3.0.1` commit
- ✅ v3 `action.yml` still declares every input this repo uses
- ✅ Branched off `main` after #48 merged — no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CB92b3G3FSTnzkfvxAPyiA
