### PR TITLE
feat(ci): auto-publish GitHub Releases on merge to main

### DIFF
--- a/.github/workflows/ci_tag_release.yml
+++ b/.github/workflows/ci_tag_release.yml
@@ -59,5 +59,6 @@ jobs:
             - `..._Chrome.zip` — Chromium browsers (Load unpacked)
             - `..._Firefox.xpi` — Firefox (Load Temporary Add-on)
           generate_release_notes: true
+          fail_on_unmatched_files: true
           prerelease: ${{ contains(github.ref, '-') }}
           draft: false

--- a/.github/workflows/ci_tag_release.yml
+++ b/.github/workflows/ci_tag_release.yml
@@ -5,6 +5,7 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -48,8 +49,15 @@ jobs:
         with:
           files: |
             builds/Cookie-AutoDelete-V3_*_Chrome.zip
-            builds/Cookie-AutoDelete-V3_*_Firefox.zip
             builds/Cookie-AutoDelete-V3_*_Firefox.xpi
-          body: This is an auto-generated tagged release - Change log will be manually inserted soon! Built artifacts are attached below. This fork distributes via GitHub Releases only -- install via 'Load unpacked' (Chrome/Edge) or 'Load Temporary Add-on' (Firefox). See the README for instructions.
+          body: |
+            Cookie AutoDelete V3 — ${{ github.ref_name }}
+
+            🟢 **Recommended (Chrome / Edge / Brave / Vivaldi & any Chromium browser):** install from the [Chrome Web Store](https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd) for automatic updates.
+
+            🦊 **Firefox or manual / sideload install:** download an artifact below — see the [README](https://github.com/vasilisplavos/Cookie-AutoDeleteV3#installation) for step-by-step instructions.
+            - `..._Chrome.zip` — Chromium browsers (Load unpacked)
+            - `..._Firefox.xpi` — Firefox (Load Temporary Add-on)
+          generate_release_notes: true
           prerelease: ${{ contains(github.ref, '-') }}
-          draft: true
+          draft: false

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -1,0 +1,86 @@
+name: Auto Release on Main
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Build artifacts but do not publish a release'
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+jobs:
+  release:
+    name: Build and Publish Release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Use Node.js 22.x
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: '22.x'
+      - name: Install Dependencies (npm ci)
+        run: npm ci --no-fund
+      - name: Resolve version from package.json
+        id: ver
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Resolved version: $VERSION"
+      - name: Check whether this version is already released
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if gh release view "v${{ steps.ver.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+            echo "Release v${{ steps.ver.outputs.version }} already exists - nothing to do."
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "Release v${{ steps.ver.outputs.version }} does not exist - will build and publish."
+          fi
+      - name: Run Tests
+        if: steps.check.outputs.exists == 'false'
+        run: npm test
+      - name: Run Lint
+        if: steps.check.outputs.exists == 'false'
+        run: npm run lint
+      - name: Run Build
+        id: build
+        if: steps.check.outputs.exists == 'false'
+        env:
+          BUILD_VERSION: v${{ steps.ver.outputs.version }}
+        run: npm run build
+      - name: Publish GitHub Release
+        id: publish
+        if: steps.check.outputs.exists == 'false' && github.event.inputs.dry_run != 'true'
+        uses: softprops/action-gh-release@718ea10b132b3b2eba29c1007bb80653f286566b # v3.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: v${{ steps.ver.outputs.version }}
+          name: v${{ steps.ver.outputs.version }}
+          draft: false
+          make_latest: true
+          generate_release_notes: true
+          body: |
+            Cookie AutoDelete V3 — v${{ steps.ver.outputs.version }}
+
+            🟢 **Recommended (Chrome / Edge / Brave / Vivaldi & any Chromium browser):** install from the [Chrome Web Store](https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd) for automatic updates.
+
+            🦊 **Firefox or manual / sideload install:** download an artifact below — see the [README](https://github.com/vasilisplavos/Cookie-AutoDeleteV3#installation) for step-by-step instructions.
+            - `..._Chrome.zip` — Chromium browsers (Load unpacked)
+            - `..._Firefox.xpi` — Firefox (Load Temporary Add-on)
+          files: |
+            builds/Cookie-AutoDelete-V3_*_Chrome.zip
+            builds/Cookie-AutoDelete-V3_*_Firefox.xpi

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -73,6 +73,7 @@ jobs:
           draft: false
           make_latest: true
           generate_release_notes: true
+          fail_on_unmatched_files: true
           body: |
             Cookie AutoDelete V3 — v${{ steps.ver.outputs.version }}
 

--- a/__tests__/tools/resolveBuildVersion.test.js
+++ b/__tests__/tools/resolveBuildVersion.test.js
@@ -1,0 +1,35 @@
+const { resolveBuildVersion } = require('../../tools/resolveBuildVersion');
+
+describe('resolveBuildVersion', () => {
+  test('BUILD_VERSION takes priority over GITHUB_REF', () => {
+    expect(
+      resolveBuildVersion({ BUILD_VERSION: 'v1.2.3', GITHUB_REF: 'refs/tags/v9.9.9' }),
+    ).toBe('v1.2.3');
+  });
+
+  test('reads a tag from GITHUB_REF, stripping refs/tags/', () => {
+    expect(resolveBuildVersion({ GITHUB_REF: 'refs/tags/v1.0.0' })).toBe('v1.0.0');
+  });
+
+  test('returns empty string for a branch ref (main push)', () => {
+    expect(resolveBuildVersion({ GITHUB_REF: 'refs/heads/main' })).toBe('');
+  });
+
+  test('falls back to TRAVIS_TAG', () => {
+    expect(resolveBuildVersion({ TRAVIS_TAG: 'v2.0.0' })).toBe('v2.0.0');
+  });
+
+  test('accepts a plain semver without the v prefix', () => {
+    expect(resolveBuildVersion({ BUILD_VERSION: '1.0.3' })).toBe('1.0.3');
+  });
+
+  test('first non-empty source wins; an invalid value yields empty (no fall-through)', () => {
+    expect(
+      resolveBuildVersion({ BUILD_VERSION: 'garbage', GITHUB_REF: 'refs/tags/v1.0.0' }),
+    ).toBe('');
+  });
+
+  test('empty env yields empty string', () => {
+    expect(resolveBuildVersion({})).toBe('');
+  });
+});

--- a/__tests__/workflows/ciTagRelease.test.js
+++ b/__tests__/workflows/ciTagRelease.test.js
@@ -1,0 +1,29 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function loadWorkflow(name) {
+  const p = path.join(__dirname, '..', '..', '.github', 'workflows', name);
+  return yaml.safeLoad(fs.readFileSync(p, 'utf8'));
+}
+
+describe('ci_tag_release.yml (manual fallback)', () => {
+  const doc = loadWorkflow('ci_tag_release.yml');
+  const jobKey = Object.keys(doc.jobs)[0];
+  const release = doc.jobs[jobKey].steps.find((s) => s.id === 'github_releases');
+
+  test('keeps the tag trigger and adds manual dispatch', () => {
+    expect(doc.on.push.tags).toBeDefined();
+    expect(doc.on).toHaveProperty('workflow_dispatch');
+  });
+
+  test('publishes (not draft)', () => {
+    expect(release.with.draft).toBe(false);
+  });
+
+  test('attaches only Chrome.zip and Firefox.xpi', () => {
+    expect(release.with.files).toContain('Chrome.zip');
+    expect(release.with.files).toContain('Firefox.xpi');
+    expect(release.with.files).not.toContain('Firefox.zip');
+  });
+});

--- a/__tests__/workflows/ciTagRelease.test.js
+++ b/__tests__/workflows/ciTagRelease.test.js
@@ -21,6 +21,17 @@ describe('ci_tag_release.yml (manual fallback)', () => {
     expect(release.with.draft).toBe(false);
   });
 
+  test('uses auto-generated notes and the Web Store body', () => {
+    expect(release.with.generate_release_notes).toBe(true);
+    expect(release.with.body).toContain(
+      'https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd',
+    );
+  });
+
+  test('fails the job on unmatched files', () => {
+    expect(release.with.fail_on_unmatched_files).toBe(true);
+  });
+
   test('attaches only Chrome.zip and Firefox.xpi', () => {
     expect(release.with.files).toContain('Chrome.zip');
     expect(release.with.files).toContain('Firefox.xpi');

--- a/__tests__/workflows/releaseOnMain.test.js
+++ b/__tests__/workflows/releaseOnMain.test.js
@@ -58,4 +58,9 @@ describe('release-on-main.yml', () => {
     expect(publish.if).toContain("steps.check.outputs.exists");
     expect(publish.if).toContain("dry_run");
   });
+
+  test('publish fails the job on unmatched files', () => {
+    const publish = stepById(doc, jobKey, 'publish');
+    expect(publish.with.fail_on_unmatched_files).toBe(true);
+  });
 });

--- a/__tests__/workflows/releaseOnMain.test.js
+++ b/__tests__/workflows/releaseOnMain.test.js
@@ -1,0 +1,55 @@
+const fs = require('fs');
+const path = require('path');
+const yaml = require('js-yaml');
+
+function loadWorkflow(name) {
+  const p = path.join(__dirname, '..', '..', '.github', 'workflows', name);
+  return yaml.safeLoad(fs.readFileSync(p, 'utf8'));
+}
+function stepById(doc, jobKey, id) {
+  return doc.jobs[jobKey].steps.find((s) => s.id === id);
+}
+
+describe('release-on-main.yml', () => {
+  const doc = loadWorkflow('release-on-main.yml');
+  const jobKey = Object.keys(doc.jobs)[0];
+
+  test('triggers on push to main and via workflow_dispatch', () => {
+    expect(doc.on.push.branches).toContain('main');
+    expect(doc.on).toHaveProperty('workflow_dispatch');
+  });
+
+  test('workflow_dispatch exposes a dry_run input', () => {
+    expect(doc.on.workflow_dispatch.inputs).toHaveProperty('dry_run');
+  });
+
+  test('grants contents: write and serializes releases', () => {
+    expect(doc.permissions.contents).toBe('write');
+    expect(doc.concurrency.group).toBe('release-main');
+  });
+
+  test('build step feeds BUILD_VERSION', () => {
+    const build = stepById(doc, jobKey, 'build');
+    expect(build.env.BUILD_VERSION).toMatch(/version/);
+  });
+
+  test('publish step is a full, latest, auto-noted release', () => {
+    const publish = stepById(doc, jobKey, 'publish');
+    expect(publish.uses).toMatch(/^softprops\/action-gh-release@[0-9a-f]{40}/);
+    expect(publish.with.draft).toBe(false);
+    expect(publish.with.make_latest).toBe(true);
+    expect(publish.with.generate_release_notes).toBe(true);
+  });
+
+  test('publish attaches only Chrome.zip and Firefox.xpi', () => {
+    const files = stepById(doc, jobKey, 'publish').with.files;
+    expect(files).toContain('Chrome.zip');
+    expect(files).toContain('Firefox.xpi');
+    expect(files).not.toContain('Firefox.zip');
+  });
+
+  test('publish is skipped on dry runs', () => {
+    const publish = stepById(doc, jobKey, 'publish');
+    expect(publish.if).toContain("dry_run");
+  });
+});

--- a/__tests__/workflows/releaseOnMain.test.js
+++ b/__tests__/workflows/releaseOnMain.test.js
@@ -28,9 +28,14 @@ describe('release-on-main.yml', () => {
     expect(doc.concurrency.group).toBe('release-main');
   });
 
+  test('defines the version-resolve and existence-check steps', () => {
+    expect(stepById(doc, jobKey, 'ver')).toBeDefined();
+    expect(stepById(doc, jobKey, 'check')).toBeDefined();
+  });
+
   test('build step feeds BUILD_VERSION', () => {
     const build = stepById(doc, jobKey, 'build');
-    expect(build.env.BUILD_VERSION).toMatch(/version/);
+    expect(build.env.BUILD_VERSION).toMatch(/^v\$\{\{.*steps\.ver\.outputs\.version/);
   });
 
   test('publish step is a full, latest, auto-noted release', () => {
@@ -50,6 +55,7 @@ describe('release-on-main.yml', () => {
 
   test('publish is skipped on dry runs', () => {
     const publish = stepById(doc, jobKey, 'publish');
+    expect(publish.if).toContain("steps.check.outputs.exists");
     expect(publish.if).toContain("dry_run");
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cookie-autodelete-v3",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cookie-autodelete-v3",
-      "version": "1.0.2",
+      "version": "1.0.3",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.1",
@@ -47,6 +47,7 @@
         "jest-date-mock": "^1.0.8",
         "jest-environment-jsdom": "^30.0.0",
         "jest-when": "^4.0.3",
+        "js-yaml": "^3.15.0",
         "prettier": "^2.8.1",
         "source-map-loader": "^5.0.0",
         "ts-jest": "^29.4.11",
@@ -8724,9 +8725,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -18343,9 +18344,9 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "js-yaml": {
-      "version": "3.14.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
       "dev": true,
       "requires": {
         "argparse": "^1.0.7",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "jest-date-mock": "^1.0.8",
     "jest-environment-jsdom": "^30.0.0",
     "jest-when": "^4.0.3",
+    "js-yaml": "^3.15.0",
     "prettier": "^2.8.1",
     "source-map-loader": "^5.0.0",
     "ts-jest": "^29.4.11",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "jest-date-mock": "^1.0.8",
     "jest-environment-jsdom": "^30.0.0",
     "jest-when": "^4.0.3",
-    "js-yaml": "^3.15.0",
+    "js-yaml": "^3.14.2",
     "prettier": "^2.8.1",
     "source-map-loader": "^5.0.0",
     "ts-jest": "^29.4.11",

--- a/tools/buildFilesDev.js
+++ b/tools/buildFilesDev.js
@@ -16,6 +16,7 @@
 const fs = require('fs');
 const path = require('path');
 const archiver = require('archiver');
+const { resolveBuildVersion } = require('./resolveBuildVersion');
 
 const BUILDS = 'builds';
 const EXT = 'extension';
@@ -38,16 +39,7 @@ console.log('GITHUB_REF:  %s', process.env.GITHUB_REF);
 console.log('TRAVIS_TAG:  %s', process.env.TRAVIS_TAG);
 console.log('GITSHA    :  %s', process.env.GITSHA);
 
-let versionTag = process.env.GITHUB_REF || process.env.TRAVIS_TAG || '';
-
-if (versionTag.startsWith('refs/tags/')) {
-  versionTag = versionTag.slice(10);
-}
-
-if (versionTag && !RegExp(/^v?\d+\.\d+\.\d+$/).test(versionTag)) {
-  console.warn('Version [ %s ] is not in valid semver form.', versionTag);
-  versionTag = '';
-}
+let versionTag = resolveBuildVersion(process.env);
 
 if (!versionTag) {
   console.log(

--- a/tools/resolveBuildVersion.js
+++ b/tools/resolveBuildVersion.js
@@ -1,0 +1,25 @@
+/**
+ * Resolves the version tag used for build-artifact filenames.
+ *
+ * Priority: BUILD_VERSION (explicit, used by the main-push release workflow)
+ * > GITHUB_REF (tag pushes) > TRAVIS_TAG (legacy). The first non-empty source
+ * wins; if that value is not valid semver (e.g. a branch ref like
+ * refs/heads/main) the result is '' so the build falls back to Dev_ naming.
+ *
+ * @param {Record<string, string|undefined>} env  Environment map (process.env).
+ * @returns {string} e.g. 'v1.0.3' / '1.0.3', or '' when no valid source.
+ */
+const SEMVER_RE = /^v?\d+\.\d+\.\d+$/;
+
+function resolveBuildVersion(env = {}) {
+  let version = env.BUILD_VERSION || env.GITHUB_REF || env.TRAVIS_TAG || '';
+  if (version.startsWith('refs/tags/')) {
+    version = version.slice('refs/tags/'.length);
+  }
+  if (version && !SEMVER_RE.test(version)) {
+    return '';
+  }
+  return version;
+}
+
+module.exports = { resolveBuildVersion };


### PR DESCRIPTION
## Why

The GitHub Releases page was out of date — only `v1.0.0` was published while the Chrome Web Store had a newer version. A Firefox / Vivaldi / Brave / Edge user visiting Releases to sideload got a stale build.

**Goal:** when work is merged to `main`, the Releases page updates automatically so the downloadable builds stay in sync with the version shipped to the Chrome Web Store.

## Distribution model

- **Chrome Web Store = primary / recommended.** Actively maintained, Chrome-first. Store links stay.
- **GitHub Releases = secondary channel** for sideloading on Firefox (`.xpi`) and any Chromium browser (`.zip`) without the store.

## What changed

- **`tools/resolveBuildVersion.js` (new) + `buildFilesDev.js`** — extracts version resolution into a pure, unit-tested helper and adds a `BUILD_VERSION` env source so main-push builds get correct `vX.Y.Z` filenames instead of `Dev_` naming.
- **`.github/workflows/release-on-main.yml` (new)** — on push to `main`, reads the version from `package.json` and publishes a `vX.Y.Z` release (Chrome.zip + Firefox.xpi, auto-generated notes) **only when that version is not already released** (idempotent via `gh release view` + a `concurrency` group). Supports a `workflow_dispatch` with a `dry_run` input.
- **`.github/workflows/ci_tag_release.yml` (fixed)** — now publishes (`draft: false`), attaches only Chrome.zip + Firefox.xpi (drops the redundant `_Firefox.zip`), uses a shared Web-Store-first release body with auto-generated notes. Kept as the manual/tag-push fallback.
- **Defense-in-depth** — `fail_on_unmatched_files: true` on both publish steps so a future glob typo fails the job instead of silently publishing an asset-less release.
- **Tests** — `js-yaml` declared as an explicit devDependency; new structural tests (`releaseOnMain`, `ciTagRelease`) assert triggers, SHA pins, `draft:false`, file globs, `generate_release_notes`, and the Web Store URL. `resolveBuildVersion` has 7 unit tests. **Full suite: 510 passing.**

## Rollout (post-merge, manual)

1. Delete the stale release: `gh release delete v1.0.0 --cleanup-tag --yes` (breaks ~9 old download links — acceptable).
2. Merging this PR is itself a push to `main` → `release-on-main.yml` runs and auto-publishes `v1.0.3` as **Latest**.

## For review — open decisions (Minor)

1. **`workflow_dispatch` on `ci_tag_release.yml` is build-only.** Its release step keeps `if: startsWith(github.ref, 'refs/tags/')`, so a manual dispatch runs tests+build but does **not** publish (the real manual path is pushing a `vX.Y.Z` tag, which works). Removing the `if:` is **not** the fix (it would tag a branch SHA and emit `Dev_`-named artifacts). Options: drop the `workflow_dispatch` trigger from this workflow (the new `release-on-main.yml` already offers a real manual path), or keep it as a CI smoke-run. Your call.
2. **Prerelease tags → `Dev_` filenames (pre-existing).** `resolveBuildVersion` rejects `v1.0.0-beta` (same regex as before), so a prerelease tag via the fallback yields `Dev_`-named artifacts. Not a regression; `release-on-main.yml` only emits `X.Y.Z`.

Out of scope (flagged, not touched): the `ci_tag_testbuilds.yml` `Cookie-AutoDelete_*` glob bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
