### PR TITLE
chore(deps): switch Dependabot to security-only updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,28 @@
 version: 2
+# -----------------------------------------------------------------------------
+# Security-only policy.
+#
+# Routine VERSION updates are disabled (open-pull-requests-limit: 0) to avoid
+# noisy major-bump PRs that break CI and have to be done by hand anyway.
+#
+# CVE-driven SECURITY updates are still wanted. Those are NOT controlled by this
+# file — they are raised automatically when GitHub detects a vulnerable
+# dependency, and require these repo settings to be ON:
+#   Settings -> Code security -> Dependabot alerts            = Enabled
+#   Settings -> Code security -> Dependabot security updates  = Enabled
+# Security updates are not affected by open-pull-requests-limit, so they still
+# come through even though version updates below are capped at 0.
+# -----------------------------------------------------------------------------
 updates:
-  # Maintain Dependencies for GitHub Actions
+  # GitHub Actions — version updates off (security updates still apply)
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "daily"
-  # Maintain Dependencies for NodeJS / npm
+    open-pull-requests-limit: 0
+  # NodeJS / npm — version updates off (security updates still apply)
   - package-ecosystem: "npm"
-    # Look for `package.json` and `lock` files in the `root` directory
     directory: "/"
-    # Check npm registry for updates every day (weekdays)
     schedule:
       interval: "daily"
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## What

Disables routine Dependabot **version updates** (`open-pull-requests-limit: 0` for both `npm` and `github-actions`) while keeping **security updates** active.

## Why

Routine version bumps were mostly noise: major-version PRs (react-dom 17→19, eslint 7→10, typescript-eslint 4→8, etc.) that break CI and have to be coordinated by hand anyway. Of all ~41 historical Dependabot PRs, none were CVE-driven.

CVE-driven security updates are what actually matter for a cookie/privacy extension. Those are unaffected by `open-pull-requests-limit` and now fire via the repo settings:

- Dependabot **alerts** → enabled
- Dependabot **security updates** → enabled

So from now on Dependabot stays quiet until GitHub detects a real vulnerability, then opens a PR.

## Note

The 8 currently-open version PRs (#51–#57, #62) are pre-existing and won't auto-close; they can be closed manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)