### PR TITLE
build: migrate web-ext-types → @types/firefox-webext-browser

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "js/ts.tsdk.path": "node_modules\\typescript\\lib"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-    "js/ts.tsdk.path": "node_modules\\typescript\\lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true
 }

--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -51,7 +51,6 @@ const sampleTab: browser.tabs.Tab = {
   isInReaderMode: false,
   lastAccessed: 12345678,
   pinned: false,
-  selected: true,
   url: 'https://example.com',
   windowId: 1,
 };
@@ -169,6 +168,7 @@ const sampleState: State = {
 
 const mockCookie: CookiePropertiesCleanup = {
   domain: 'test.com',
+  firstPartyDomain: '',
   hostOnly: true,
   hostname: 'test.com',
   httpOnly: true,

--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -168,7 +168,6 @@ const sampleState: State = {
 
 const mockCookie: CookiePropertiesCleanup = {
   domain: 'test.com',
-  firstPartyDomain: '',
   hostOnly: true,
   hostname: 'test.com',
   httpOnly: true,
@@ -1038,7 +1037,7 @@ describe('CleanupService', () => {
   describe('clearLocalStorageForThisDomain()', () => {
     it('should clear localstorage from active tab (via tabs.executeScript)', async () => {
       when(global.browser.tabs.executeScript)
-        .calledWith(undefined, expect.any(Object))
+        .calledWith(expect.any(Object))
         .mockResolvedValue([{ local: 2, session: 0 }] as never);
       expect(
         await clearLocalStorageForThisDomain(initialState, sampleTab),
@@ -1048,7 +1047,7 @@ describe('CleanupService', () => {
     });
     it('should show error notification if browser.tabs.executeScript threw an error', async () => {
       when(global.browser.tabs.executeScript)
-        .calledWith(undefined, expect.any(Object))
+        .calledWith(expect.any(Object))
         .mockRejectedValue(new Error('test') as never);
       expect(
         await clearLocalStorageForThisDomain(initialState, sampleTab),
@@ -1059,7 +1058,7 @@ describe('CleanupService', () => {
     });
     it('should only show the no cleanup done notification if browser.tabs.executeScript threw a non-error type', async () => {
       when(global.browser.tabs.executeScript)
-        .calledWith(undefined, expect.any(Object))
+        .calledWith(expect.any(Object))
         .mockRejectedValue('error' as never);
       expect(
         await clearLocalStorageForThisDomain(initialState, sampleTab),

--- a/__tests__/services/ContextMenuEvents.spec.ts
+++ b/__tests__/services/ContextMenuEvents.spec.ts
@@ -82,7 +82,6 @@ const sampleTab: browser.tabs.Tab = {
   isInReaderMode: false,
   lastAccessed: 12345678,
   pinned: false,
-  selected: true,
   url: 'https://www.example.com',
   windowId: 1,
 };

--- a/__tests__/services/ContextualIdentitiesEvents.spec.ts
+++ b/__tests__/services/ContextualIdentitiesEvents.spec.ts
@@ -84,7 +84,9 @@ const defaultContextualIdentity: browser.contextualIdentities.ContextualIdentity
   {
     cookieStoreId: 'firefox-container-0',
     color: 'blue',
+    colorCode: '#000000',
     icon: 'fingerprint',
+    iconUrl: '',
     name: 'Testing Container',
   };
 

--- a/__tests__/services/CookieEvents.spec.ts
+++ b/__tests__/services/CookieEvents.spec.ts
@@ -23,6 +23,7 @@ const spyLib: JestSpyObject = global.generateSpies(Lib);
 
 const defaultCookie: browser.cookies.Cookie = {
   domain: 'domain.com',
+  firstPartyDomain: '',
   hostOnly: false,
   httpOnly: false,
   name: 'CookieName',
@@ -46,7 +47,6 @@ const defaultTab: browser.tabs.Tab = {
   isInReaderMode: false,
   lastAccessed: 12345678,
   pinned: false,
-  selected: true,
   url: 'https://domain.com',
   windowId: 1,
 };

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -56,9 +56,8 @@ import {
 
 import ipaddr from 'ipaddr.js';
 
-const mockCookie: browser.cookies.Cookie = {
+const mockCookie: browser.cookies.CookieProperties = {
   domain: 'domain.com',
-  firstPartyDomain: '',
   hostOnly: true,
   httpOnly: true,
   name: 'blah',
@@ -492,9 +491,8 @@ describe('Library Functions', () => {
         .mockResolvedValue([testCookie] as never);
     });
 
-    const testCookie: browser.cookies.Cookie = {
+    const testCookie: browser.cookies.CookieProperties = {
       domain: 'domain.com',
-      firstPartyDomain: '',
       hostOnly: true,
       httpOnly: true,
       name: 'blah',
@@ -1508,7 +1506,6 @@ describe('Library Functions', () => {
       };
       const cookieAPIAttributes = {
         ...mockCookie,
-        firstPartyDomain: '',
       };
       const results = returnOptionalCookieAPIAttributes(
         state,

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -58,6 +58,7 @@ import ipaddr from 'ipaddr.js';
 
 const mockCookie: browser.cookies.Cookie = {
   domain: 'domain.com',
+  firstPartyDomain: '',
   hostOnly: true,
   httpOnly: true,
   name: 'blah',
@@ -493,6 +494,7 @@ describe('Library Functions', () => {
 
     const testCookie: browser.cookies.Cookie = {
       domain: 'domain.com',
+      firstPartyDomain: '',
       hostOnly: true,
       httpOnly: true,
       name: 'blah',
@@ -516,7 +518,6 @@ describe('Library Functions', () => {
       isInReaderMode: false,
       lastAccessed: 12345678,
       pinned: false,
-      selected: true,
       url: 'https://www.example.com',
       windowId: 1,
     };

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -1506,6 +1506,7 @@ describe('Library Functions', () => {
       };
       const cookieAPIAttributes = {
         ...mockCookie,
+        firstPartyDomain: '',
       };
       const results = returnOptionalCookieAPIAttributes(
         state,

--- a/__tests__/services/SettingService.spec.ts
+++ b/__tests__/services/SettingService.spec.ts
@@ -86,7 +86,6 @@ const defaultTab: browser.tabs.Tab = {
   isInReaderMode: false,
   lastAccessed: 12345678,
   pinned: false,
-  selected: true,
   url: 'https://domain.com',
   windowId: 1,
 };

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -128,9 +128,8 @@ describe('TabEvents', () => {
         .mockResolvedValue([testCookie] as never);
     });
 
-    const testCookie: browser.cookies.Cookie = {
+    const testCookie: browser.cookies.CookieProperties = {
       domain: 'domain.com',
-      firstPartyDomain: '',
       hostOnly: true,
       httpOnly: true,
       name: 'blah',

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -91,7 +91,6 @@ const sampleTab: browser.tabs.Tab = {
   isInReaderMode: false,
   lastAccessed: 12345678,
   pinned: false,
-  selected: true,
   url: 'https://www.example.com',
   windowId: 1,
 };
@@ -131,6 +130,7 @@ describe('TabEvents', () => {
 
     const testCookie: browser.cookies.Cookie = {
       domain: 'domain.com',
+      firstPartyDomain: '',
       hostOnly: true,
       httpOnly: true,
       name: 'blah',

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "webextension-polyfill": "^0.8.0"
       },
       "devDependencies": {
+        "@types/firefox-webext-browser": "^143.0.0",
         "@types/jest": "^30.0.0",
         "@types/jest-when": "^3.5.2",
         "@types/react": "^17.0.52",
@@ -47,13 +48,12 @@
         "jest-date-mock": "^1.0.8",
         "jest-environment-jsdom": "^30.0.0",
         "jest-when": "^4.0.3",
-        "js-yaml": "^3.15.0",
+        "js-yaml": "^3.14.2",
         "prettier": "^2.8.1",
         "source-map-loader": "^5.0.0",
         "ts-jest": "^29.4.11",
         "ts-loader": "^9.4.2",
         "typescript": "^4.9.4",
-        "web-ext-types": "^3.2.1",
         "webpack": "^5.75.0",
         "webpack-bundle-analyzer": "^5.3.0",
         "webpack-cli": "^4.10.0"
@@ -2268,6 +2268,13 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/firefox-webext-browser": {
+      "version": "143.0.0",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-143.0.0.tgz",
+      "integrity": "sha512-865dYKMOP0CllFyHmgXV4IQgVL51OSQQCwSoihQ17EwugePKFSAZRc0EI+y7Ly4q7j5KyURlA7LgRpFieO4JOw==",
       "dev": true,
       "license": "MIT"
     },
@@ -11693,12 +11700,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/web-ext-types": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-ext-types/-/web-ext-types-3.2.1.tgz",
-      "integrity": "sha512-oQZYDU3W8X867h8Jmt3129kRVKklz70db40Y6OzoTTuzOJpF/dB2KULJUf0txVPyUUXuyzV8GmT3nVvRHoG+Ew==",
-      "dev": true
-    },
     "node_modules/webextension-polyfill": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/webextension-polyfill/-/webextension-polyfill-0.8.0.tgz",
@@ -13945,6 +13946,12 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
       "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true
+    },
+    "@types/firefox-webext-browser": {
+      "version": "143.0.0",
+      "resolved": "https://registry.npmjs.org/@types/firefox-webext-browser/-/firefox-webext-browser-143.0.0.tgz",
+      "integrity": "sha512-865dYKMOP0CllFyHmgXV4IQgVL51OSQQCwSoihQ17EwugePKFSAZRc0EI+y7Ly4q7j5KyURlA7LgRpFieO4JOw==",
       "dev": true
     },
     "@types/hoist-non-react-statics": {
@@ -20359,12 +20366,6 @@
         "glob-to-regexp": "^0.4.1",
         "graceful-fs": "^4.1.2"
       }
-    },
-    "web-ext-types": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/web-ext-types/-/web-ext-types-3.2.1.tgz",
-      "integrity": "sha512-oQZYDU3W8X867h8Jmt3129kRVKklz70db40Y6OzoTTuzOJpF/dB2KULJUf0txVPyUUXuyzV8GmT3nVvRHoG+Ew==",
-      "dev": true
     },
     "webextension-polyfill": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "webextension-polyfill": "^0.8.0"
   },
   "devDependencies": {
+    "@types/firefox-webext-browser": "^143.0.0",
     "@types/jest": "^30.0.0",
     "@types/jest-when": "^3.5.2",
     "@types/react": "^17.0.52",
@@ -71,7 +72,6 @@
     "ts-jest": "^29.4.11",
     "ts-loader": "^9.4.2",
     "typescript": "^4.9.4",
-    "web-ext-types": "^3.2.1",
     "webpack": "^5.75.0",
     "webpack-bundle-analyzer": "^5.3.0",
     "webpack-cli": "^4.10.0"

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -311,7 +311,7 @@ browser.runtime.onConnect.addListener(async (p) => {
 if (browser.contextMenus) {
   browser.contextMenus.onClicked.addListener(async (info, tab) => {
     await ready();
-    ContextMenuEvents.onContextMenuClicked(info, tab);
+    if (tab) ContextMenuEvents.onContextMenuClicked(info, tab);
   });
 }
 

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -376,7 +376,7 @@ export const cleanCookies = async (
   state: State,
   markedForDeletion: CleanReasonObject[],
 ): Promise<void> => {
-  const promiseArr: Promise<browser.cookies.Cookie | null>[] = [];
+  const promiseArr: Promise<unknown>[] = [];
   markedForDeletion.forEach((obj) => {
     const cookieProperties = obj.cookie;
     const cookieAPIProperties = returnOptionalCookieAPIAttributes(state, {
@@ -487,7 +487,7 @@ export const clearLocalStorageForThisDomain = async (
   try {
     let local = 0;
     let session = 0;
-    const result = await browser.tabs.executeScript(undefined, {
+    const result = await browser.tabs.executeScript({
       code: `var cad_r = {local: window.localStorage.length, session: window.sessionStorage.length};window.localStorage.clear();window.sessionStorage.clear();cad_r;`,
     });
     result.forEach((frame: { [key: string]: any }) => {

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -738,7 +738,9 @@ export const prepareCleanupDomains = (
 /**
  * Puts the domain in the right format for browser.cookies.remove()
  */
-export const prepareCookieDomain = (cookie: browser.cookies.Cookie): string => {
+export const prepareCookieDomain = (
+  cookie: browser.cookies.CookieProperties,
+): string => {
   let cookieDomain = cookie.domain.trim();
   if (cookieDomain.length === 0 && cookie.path.trim().length !== 0) {
     // No Domain - presuming local file (file:// protocol)

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -112,7 +112,7 @@ export const convertVersionToNumber = (version?: string): number => {
  * @param action The EventListenerAction (add/remove).
  */
 export const eventListenerActions = (
-  event: EvListener<any>,
+  event: WebExtEvent<any>,
   listener: (...args: any[]) => void,
   action: EventListenerAction,
 ): void => {

--- a/src/typings/Webext.d.ts
+++ b/src/typings/Webext.d.ts
@@ -23,4 +23,34 @@ declare namespace browser.cookies {
   type OptionalCookieProperties = Partial<CookieProperties>;
 }
 
+declare namespace browser.tabs {
+  // Firefox tabs.onUpdated changeInfo, including CAD's cookieChanged extension;
+  // the new types expose this only as the internal _OnUpdatedChangeInfo.
+  interface TabChangeInfo {
+    attention?: boolean;
+    audible?: boolean;
+    cookieChanged?: {
+      removed: boolean;
+      cookie: browser.cookies.Cookie;
+      cause: browser.cookies.OnChangedCause;
+    };
+    discarded?: boolean;
+    favIconUrl?: string;
+    hidden?: boolean;
+    isArticle?: boolean;
+    mutedInfo?: browser.tabs.MutedInfo;
+    pinned?: boolean;
+    status?: string;
+    title?: string;
+    url?: string;
+  }
+}
+
+declare namespace browser.contextualIdentities {
+  // Project-named change-info type (native exposes it only as _OnUpdatedChangeInfo).
+  type contextualIdentitiesChangeInfo = {
+    contextualIdentity: ContextualIdentity;
+  };
+}
+
 declare module 'redux-webext';

--- a/src/typings/Webext.d.ts
+++ b/src/typings/Webext.d.ts
@@ -16,10 +16,14 @@
  */
 
 declare namespace browser.cookies {
-  // Native Cookie already carries firstPartyDomain (required) and a native
-  // partitionKey (PartitionKey with topLevelSite). CookieProperties is the
-  // project's working cookie shape; it extends the native Cookie unchanged.
-  interface CookieProperties extends browser.cookies.Cookie {}
+  // CookieProperties is the project's working cookie shape. firstPartyDomain is
+  // kept OPTIONAL (the native Cookie marks it required, but at runtime Firefox
+  // only sets it under first-party isolation and Chrome never does), so code and
+  // fixtures treat an unset firstPartyDomain as undefined as they always have.
+  interface CookieProperties
+    extends Omit<browser.cookies.Cookie, 'firstPartyDomain'> {
+    firstPartyDomain?: string;
+  }
   type OptionalCookieProperties = Partial<CookieProperties>;
 }
 

--- a/src/typings/Webext.d.ts
+++ b/src/typings/Webext.d.ts
@@ -51,7 +51,8 @@ declare namespace browser.tabs {
 }
 
 declare namespace browser.contextualIdentities {
-  // Project-named change-info type (native exposes it only as _OnUpdatedChangeInfo).
+  // Project-named change-info type (native exposes it only as the internal
+  // _OnCreatedChangeInfo / _OnRemovedChangeInfo / _OnUpdatedChangeInfo).
   type contextualIdentitiesChangeInfo = {
     contextualIdentity: ContextualIdentity;
   };

--- a/src/typings/Webext.d.ts
+++ b/src/typings/Webext.d.ts
@@ -15,92 +15,12 @@
  * SOFTWARE.
  */
 
-declare namespace browser.browsingData {
-  function remove(
-    removalOptions: {
-      hostnames?: string[];
-      origins?: string[]; // Added in Chrome 74+
-      since?: number;
-    },
-    dataTypeSet: {
-      cache?: boolean;
-      indexedDB?: boolean;
-      localStorage?: boolean;
-      pluginData?: boolean;
-      serviceWorkers?: boolean;
-    },
-  ): Promise<void>;
-}
-
 declare namespace browser.cookies {
-  interface CookiePartitionKey {
-    topLevelSite?: string;
-    hasCrossSiteAncestor?: boolean; // Chrome 130+
-  }
-  interface CookieProperties extends browser.cookies.Cookie {
-    firstPartyDomain?: string;
-    partitionKey?: CookiePartitionKey;
-  }
+  // Native Cookie already carries firstPartyDomain (required) and a native
+  // partitionKey (PartitionKey with topLevelSite). CookieProperties is the
+  // project's working cookie shape; it extends the native Cookie unchanged.
+  interface CookieProperties extends browser.cookies.Cookie {}
   type OptionalCookieProperties = Partial<CookieProperties>;
-
-  // CHIPS: the bundled web-ext-types predates partitioned cookies, so add
-  // overloads that accept partitionKey in getAll / remove details.
-  function getAll(details: OptionalCookieProperties): Promise<Cookie[]>;
-  function remove(
-    details: OptionalCookieProperties & { url: string; name: string },
-  ): Promise<Cookie | null>;
-}
-
-// Until web-ext-types land this, per https://github.com/kelseasy/web-ext-types/issues/81#issuecomment-527758881
-declare namespace browser.contextMenus {
-  type ContextType = browser.menus.ContextType;
-  type ItemType = browser.menus.ItemType;
-  type OnClickData = browser.menus.OnClickData;
-  const create: typeof browser.menus.create;
-  const getTargetElement: typeof browser.menus.getTargetElement;
-  const refresh: typeof browser.menus.refresh;
-  const remove: typeof browser.menus.remove;
-  const removeAll: typeof browser.menus.removeAll;
-  const update: typeof browser.menus.update;
-  const onClicked: typeof browser.menus.onClicked;
-  const onHidden: typeof browser.menus.onHidden;
-  const onShown: typeof browser.menus.onShown;
-}
-
-// Until web-ext-types land events into it.
-declare namespace browser.contextualIdentities {
-  type contextualIdentitiesChangeInfo = {
-    contextualIdentity: ContextualIdentity;
-  };
-  const onCreated: Listener<contextualIdentitiesChangeInfo>;
-  const onRemoved: Listener<contextualIdentitiesChangeInfo>;
-  const onUpdated: Listener<contextualIdentitiesChangeInfo>;
-}
-
-declare namespace browser.tabs {
-  interface TabChangeInfo {
-    attention?: boolean;
-    audible?: boolean;
-    cookieChanged?: {
-      removed: boolean;
-      cookie: browser.cookies.Cookie;
-      cause: browser.cookies.OnChangedCause;
-    };
-    discarded?: boolean;
-    favIconUrl?: string;
-    hidden?: boolean;
-    isArticle?: boolean;
-    mutedInfo?: browser.tabs.MutedInfo;
-    pinned?: boolean;
-    status?: string;
-    title?: string;
-    url?: string;
-  }
 }
 
 declare module 'redux-webext';
-
-declare namespace browser {
-  // MV3 alias. webextension-polyfill 0.8+ proxies browserAction <-> action at runtime.
-  const action: typeof browser.browserAction;
-}

--- a/src/ui/settings/App.tsx
+++ b/src/ui/settings/App.tsx
@@ -38,14 +38,14 @@ class App extends Component<OwnProps> {
       (this.props.sizeSetting as number) || 16
     }px`;
     const tab = await browser.tabs.getCurrent();
-    if (!tab) return;
-    const tabURL = new URL(tab.url || '');
+    if (!tab || !tab.url) return;
+    const tabURL = new URL(tab.url);
     this.setState({
       activeTab:
         tabURL.hash !== '' || undefined
           ? tabURL.hash.slice(1)
           : 'tabWelcome',
-      settingsURL: tab.url ?? '',
+      settingsURL: tab.url,
       tabId: tab.id ?? 0,
     });
   }

--- a/src/ui/settings/App.tsx
+++ b/src/ui/settings/App.tsx
@@ -38,14 +38,15 @@ class App extends Component<OwnProps> {
       (this.props.sizeSetting as number) || 16
     }px`;
     const tab = await browser.tabs.getCurrent();
+    if (!tab) return;
     const tabURL = new URL(tab.url || '');
     this.setState({
       activeTab:
         tabURL.hash !== '' || undefined
           ? tabURL.hash.slice(1)
           : 'tabWelcome',
-      settingsURL: tab.url,
-      tabId: tab.id,
+      settingsURL: tab.url ?? '',
+      tabId: tab.id ?? 0,
     });
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -42,7 +42,6 @@
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     "typeRoots": [
       "node_modules/@types",
-      "node_modules/web-ext-types",
       "src/typings"
     ] /* List of folders to include type definitions from. */,
     // "types": [],                           /* Type declaration files to be included in compilation. */


### PR DESCRIPTION
## Problem
`browser.*` was typed by the stale, unmaintained `web-ext-types@3.2.1`, loaded through a **non-standard typeRoot** (`node_modules/web-ext-types` in `tsconfig.json`). `tsc`/webpack honour that typeRoot so the build was green, but many editors/TS servers do not — surfacing spurious errors such as `Property 'i18n' does not exist on type 'typeof browser'` (ts2339) even though `browser.i18n` is used in 261 places.

## What this does
Replaces it with the maintained DefinitelyTyped package **`@types/firefox-webext-browser@^143`**, which lives in `node_modules/@types` and is auto-discovered by the standard mechanism every IDE honours — removing both the typeRoot hack and the spurious editor errors.

The new types are schema-generated and much stricter, so this is a compile-driven migration:

- **Stub cleanup** (`src/typings/Webext.d.ts`): removed every hand-written stub the new package provides natively — `browser.action`, `browsingData`, **`contextMenus`** (native; the alias was dropped — diverges from the original plan, which assumed only `menus` existed), `contextualIdentities` events, and the CHIPS `partitionKey` overloads (native `PartitionKey`). Kept only the genuinely project-specific declarations: `tabs.TabChangeInfo` (with CAD's `cookieChanged` extension) and `contextualIdentities.contextualIdentitiesChangeInfo` (native exposes these only as internal `_On*ChangeInfo` types), plus the `redux-webext` module.
- **`CookieProperties`** now `extends Omit<Cookie, 'firstPartyDomain'>` with `firstPartyDomain?` optional — modelling the runtime accurately (Firefox sets it only under first-party isolation; Chrome never).
- **Null-safety guards** the stricter types surfaced (all strictly defensive, no behaviour change): `App.tsx` / `background/index.ts` (`Tab | undefined`), `Libs.ts` (`EvListener` → native `WebExtEvent`), `CleanupService.ts` (`executeScript` single-arg active-tab overload, `promiseArr` discard type).
- **Test fixtures** updated to the stricter shapes (typed `Cookie` vs `CookieProperties` consistently; `Tab` no longer accepts `selected`; `ContextualIdentity` requires `iconUrl`/`colorCode`).

## Behaviour
No runtime behaviour change — the full suite is the safety net.

## Verification
- `npm test` → **518/518** passing
- `npm run compile` → clean (pre-existing bundle-size warnings only)
- `npm run lint` → clean
- `browser.i18n` resolves via standard `@types` (no `web-ext-types` typeRoot remaining)

Incidental: the package-lock root devDependencies mirror syncs `js-yaml` `^3.15.0 → ^3.14.2` to match `package.json`'s long-standing `^3.14.2` (removes a pre-existing inconsistency; no installed version changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)