### PR TITLE
fix(#12): route benign MV3 diagnostics through debug-gated cadLog

### DIFF
--- a/__tests__/services/StoreUser.spec.ts
+++ b/__tests__/services/StoreUser.spec.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2026 Vasilis Plavos
+ * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
+ */
+import { Store } from 'redux';
+import StoreUser from '../../src/services/StoreUser';
+
+// NOTE: order matters — the "before init()" case must run first, because
+// StoreUser holds the store in module-level static state for the whole file.
+describe('StoreUser.safeState', () => {
+  it('returns null before init()', () => {
+    expect.assertions(1);
+    expect(StoreUser.safeState).toBeNull();
+  });
+
+  it('returns the current state after init()', () => {
+    expect.assertions(1);
+    const sentinel = { sentinel: true } as unknown as State;
+    StoreUser.init({ getState: () => sentinel } as unknown as Store);
+    expect(StoreUser.safeState).toBe(sentinel);
+  });
+});

--- a/__tests__/services/StoreUser.spec.ts
+++ b/__tests__/services/StoreUser.spec.ts
@@ -5,9 +5,11 @@
 import { Store } from 'redux';
 import StoreUser from '../../src/services/StoreUser';
 
-// NOTE: order matters — the "before init()" case must run first, because
-// StoreUser holds the store in module-level static state for the whole file.
 describe('StoreUser.safeState', () => {
+  beforeEach(() => {
+    StoreUser._resetForTests();
+  });
+
   it('returns null before init()', () => {
     expect.assertions(1);
     expect(StoreUser.safeState).toBeNull();

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build:firefox": "npm run compile && node ./tools/buildFilesDev.js --target=firefox",
     "compile": "webpack --config webpack.config.js --color",
     "dev": "webpack --config webpack.config.js --progress --color --watch",
-    "lint": "eslint -c .eslintrc.json --ext .ts src/",
+    "lint": "eslint -c .eslintrc.json --max-warnings 0 --ext .ts src/",
     "test": "jest",
     "test:coverage": "jest --coverage",
     "test-all": "npm run test && npm run lint"

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -242,8 +242,14 @@ browser.runtime.onMessage.addListener((msg: any, _sender: browser.runtime.Messag
         const arg = Object.keys(actionData).length ? payload : undefined;
         getStore().dispatch(actionFn(arg));
       } else {
-        // eslint-disable-next-line no-console
-        console.warn('[CAD] redux-webext DISPATCH received unknown action type:', type);
+        cadLog(
+          {
+            msg: '[CAD] redux-webext DISPATCH received unknown action type',
+            type: 'warn',
+            x: { type },
+          },
+          getSetting(getStore().getState(), SettingID.DEBUG_MODE) as boolean,
+        );
       }
       sendResponse(undefined);
     })();
@@ -320,6 +326,9 @@ ready().then(async () => {
     await ContextMenuEvents.menuInit();
   }
 }).catch((err) => {
+  // Intentional always-on error: a genuine init failure must surface even when
+  // DEBUG_MODE is off (it belongs in bug reports), and the store may not be ready
+  // here to gate on. Deliberately not routed through cadLog.
   // eslint-disable-next-line no-console
   console.error('[CAD] context menu init failed:', err);
 });

--- a/src/background/lifecycle.ts
+++ b/src/background/lifecycle.ts
@@ -29,6 +29,8 @@ let _store: Store<State, ReduxAction> | null = null;
 export function ready(): Promise<void> {
   if (!_ready) {
     _ready = init().catch((err) => {
+      // Intentional always-on error: init failed, so the store/DEBUG_MODE may not
+      // exist yet to gate on, and this belongs in bug reports regardless.
       // eslint-disable-next-line no-console
       console.error('[CAD] background init failed (will retry on next ready()):', err);
       _ready = null; // Allow retry on next call.
@@ -164,6 +166,8 @@ function saveSubscriber(): void {
   _saveTimer = setTimeout(() => {
     _saveTimer = null;
     flushSave().catch((err) => {
+      // Intentional always-on error: a failed save is a genuine problem worth
+      // surfacing even when DEBUG_MODE is off.
       // eslint-disable-next-line no-console
       console.error('flushSave failed:', err);
     });

--- a/src/services/BrowserActionService.ts
+++ b/src/services/BrowserActionService.ts
@@ -20,12 +20,26 @@ import StoreUser from './StoreUser';
 // and stay silent — via cadLog's output gate — unless debug logging is enabled.
 // Normalizing the Error keeps cadLog's JSON.stringify from flattening it to `{}`.
 function bacWarn(msg: string, err: unknown): void {
-  const state = StoreUser.safeState;
-  const debug = state ? (getSetting(state, SettingID.DEBUG_MODE) as boolean) : false;
-  const x =
-    err instanceof Error
-      ? { name: err.name, message: err.message, stack: err.stack }
-      : err;
+  // Never let diagnostic logging throw out of the catch block it runs in.
+  let debug = false;
+  try {
+    const state = StoreUser.safeState;
+    debug = state ? (getSetting(state, SettingID.DEBUG_MODE) as boolean) : false;
+  } catch {
+    debug = false;
+  }
+  // Normalize Error-like objects (incl. DOMException, whose props live on the
+  // prototype) so cadLog's JSON.stringify doesn't flatten them to `{}`.
+  const isErrorLike =
+    err instanceof Error ||
+    (typeof err === 'object' && err !== null && 'message' in err);
+  const x = isErrorLike
+    ? {
+        name: (err as { name?: unknown }).name,
+        message: (err as { message?: unknown }).message,
+        stack: (err as { stack?: unknown }).stack,
+      }
+    : err;
   cadLog({ msg, type: 'warn', x }, debug);
 }
 

--- a/src/services/BrowserActionService.ts
+++ b/src/services/BrowserActionService.ts
@@ -18,7 +18,6 @@ import StoreUser from './StoreUser';
 // BrowserActionService has no `state` in scope and its functions can run during
 // early service-worker startup, so read DEBUG_MODE defensively (null-tolerant)
 // and stay silent — via cadLog's output gate — unless debug logging is enabled.
-// Normalizing the Error keeps cadLog's JSON.stringify from flattening it to `{}`.
 function bacWarn(msg: string, err: unknown): void {
   // Never let diagnostic logging throw out of the catch block it runs in.
   let debug = false;
@@ -26,13 +25,13 @@ function bacWarn(msg: string, err: unknown): void {
     const state = StoreUser.safeState;
     debug = state ? (getSetting(state, SettingID.DEBUG_MODE) as boolean) : false;
   } catch {
-    debug = false;
+    // store not ready or settings malformed → stay silent (debug already false)
   }
-  // Normalize Error-like objects (incl. DOMException, whose props live on the
-  // prototype) so cadLog's JSON.stringify doesn't flatten them to `{}`.
+  // Normalize Error-like objects — real Errors and DOMException both expose
+  // `message` on the prototype — so cadLog's JSON.stringify doesn't flatten
+  // them to `{}`.
   const isErrorLike =
-    err instanceof Error ||
-    (typeof err === 'object' && err !== null && 'message' in err);
+    typeof err === 'object' && err !== null && 'message' in err;
   const x = isErrorLike
     ? {
         name: (err as { name?: unknown }).name,

--- a/src/services/BrowserActionService.ts
+++ b/src/services/BrowserActionService.ts
@@ -12,7 +12,22 @@
  * SOFTWARE.
  */
 
-import { getHostname, returnMatchedExpressionObject } from './Libs';
+import { cadLog, getHostname, getSetting, returnMatchedExpressionObject } from './Libs';
+import StoreUser from './StoreUser';
+
+// BrowserActionService has no `state` in scope and its functions can run during
+// early service-worker startup, so read DEBUG_MODE defensively (null-tolerant)
+// and stay silent — via cadLog's output gate — unless debug logging is enabled.
+// Normalizing the Error keeps cadLog's JSON.stringify from flattening it to `{}`.
+function bacWarn(msg: string, err: unknown): void {
+  const state = StoreUser.safeState;
+  const debug = state ? (getSetting(state, SettingID.DEBUG_MODE) as boolean) : false;
+  const x =
+    err instanceof Error
+      ? { name: err.name, message: err.message, stack: err.stack }
+      : err;
+  cadLog({ msg, type: 'warn', x }, debug);
+}
 
 // MV3 service workers can't reliably resolve relative icon paths during early
 // startup (Chromium bug #40058177). Convert paths to ImageData up-front via
@@ -37,8 +52,7 @@ async function loadIconData(path: string): Promise<ImageData | null> {
     iconCache.set(path, data);
     return data;
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn(`[CAD] loadIconData failed for ${path}:`, err);
+    bacWarn(`[CAD] loadIconData failed for ${path}`, err);
     return null;
   }
 }
@@ -55,8 +69,7 @@ export const showNumberOfCookiesInIcon = (
         text: `${cookieLength === 0 ? '' : cookieLength.toString()}`,
       });
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn('[CAD] browser.action.setBadgeText failed:', err);
+      bacWarn('[CAD] browser.action.setBadgeText failed', err);
     }
   }
   if (browser.action.setBadgeTextColor) {
@@ -66,8 +79,7 @@ export const showNumberOfCookiesInIcon = (
         tabId: tab.id,
       });
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn('[CAD] browser.action.setBadgeTextColor failed:', err);
+      bacWarn('[CAD] browser.action.setBadgeTextColor failed', err);
     }
   }
 };
@@ -95,8 +107,7 @@ export const showNumberOfCookiesInTitle = async (
       }),
     );
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn('[CAD] browser.action.getTitle failed:', err);
+    bacWarn('[CAD] browser.action.getTitle failed', err);
   }
   const newData = {
     cookies: otherInfo.cookieLength || (curData && curData[2]) || 0,
@@ -109,8 +120,7 @@ export const showNumberOfCookiesInTitle = async (
       title: `${tabTitle} [${newData.list}] (${newData.cookies})`,
     });
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn('[CAD] browser.action.setTitle failed:', err);
+    bacWarn('[CAD] browser.action.setTitle failed', err);
   }
 };
 
@@ -128,8 +138,7 @@ const setBadgeColor = (tab: browser.tabs.Tab, color = 'default') => {
         tabId: tab.id,
       });
     } catch (err) {
-      // eslint-disable-next-line no-console
-      console.warn('[CAD] browser.action.setBadgeBackgroundColor failed:', err);
+      bacWarn('[CAD] browser.action.setBadgeBackgroundColor failed', err);
     }
   }
 };
@@ -149,8 +158,7 @@ const setIconColor = async (
       try {
         await browser.action.setIcon({ imageData: { 48: imageData }, tabId: tab.id });
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn(`[CAD] browser.action.setIcon (tab) failed for ${iconPath}:`, err);
+        bacWarn(`[CAD] browser.action.setIcon (tab) failed for ${iconPath}`, err);
       }
     }
   }
@@ -169,8 +177,7 @@ export const setGlobalIcon = async (enabled: boolean): Promise<void> => {
   try {
     await browser.action.setIcon({ imageData: { 48: imageData } });
   } catch (err) {
-    // eslint-disable-next-line no-console
-    console.warn(`[CAD] browser.action.setIcon (global) failed for ${iconPath}:`, err);
+    bacWarn(`[CAD] browser.action.setIcon (global) failed for ${iconPath}`, err);
   }
 
   const tabAwait = await browser.tabs.query({ windowType: 'normal' });
@@ -179,8 +186,7 @@ export const setGlobalIcon = async (enabled: boolean): Promise<void> => {
       try {
         await browser.action.setIcon({ imageData: { 48: imageData }, tabId: tab.id });
       } catch (err) {
-        // eslint-disable-next-line no-console
-        console.warn(`[CAD] browser.action.setIcon (tab) failed for ${iconPath}:`, err);
+        bacWarn(`[CAD] browser.action.setIcon (tab) failed for ${iconPath}`, err);
       }
     }
   }

--- a/src/services/StoreUser.ts
+++ b/src/services/StoreUser.ts
@@ -27,5 +27,10 @@ export default class StoreUser {
     return StoreUser._store ? StoreUser._store.getState() : null;
   }
 
+  /** Test-only: reset the module-level store so tests don't depend on order. */
+  public static _resetForTests(): void {
+    StoreUser._store = null;
+  }
+
   private static _store: Store<State, ReduxAction> | null = null;
 }

--- a/src/services/StoreUser.ts
+++ b/src/services/StoreUser.ts
@@ -22,5 +22,10 @@ export default class StoreUser {
     return StoreUser._store;
   }
 
+  /** Non-throwing state read for modules that may run before ready(). Null if store not initialized. */
+  public static get safeState(): State | null {
+    return StoreUser._store ? StoreUser._store.getState() : null;
+  }
+
   private static _store: Store<State, ReduxAction> | null = null;
 }


### PR DESCRIPTION
Fixes #12. Supersedes #14.

## Why not #14

`main` is already lint-clean, but it got there by putting an inline
`// eslint-disable-next-line no-console` on all 13 `console.*` sites — which
silences ESLint while still shipping the noise to **every end user's console**.
PR #14 has the same end-user behaviour: it wraps the calls in a new
`Diagnostics.ts` helper that logs **unconditionally**, duplicating a logger we
already have. Neither actually fixes what the issue is about.

This branch does. It treats each site by intent, using the existing debug-gated
logger `cadLog` (`src/services/Libs.ts`) instead of inventing a second one.

## What changed

- **10 benign warnings** (the 9 `browser.action.*` badge/icon/title failures in
  `BrowserActionService.ts` + the "unknown action type" warning in
  `background/index.ts`) now go through `cadLog`, gated on the `DEBUG_MODE`
  setting. **Silent for end users** (default off); structured and version-tagged
  when a developer turns debug logging on.
- **3 genuine errors** (context-menu init, background init, `flushSave`) stay as
  `console.error` — **always visible** — with their `eslint-disable` plus a
  one-line comment explaining why (real failures belong in bug reports, and the
  store may not exist yet to gate on).
- **New `StoreUser.safeState`** — a non-throwing state accessor so
  `BrowserActionService` (which has no `state` in scope) can read `DEBUG_MODE`
  without creating an import cycle with `background/lifecycle`.
- **`bacWarn`** normalizes error payloads (incl. `DOMException`) so `cadLog`'s
  `JSON.stringify` doesn't flatten them to `{}`, and never throws out of the
  `catch` block it runs in.
- **`--max-warnings 0`** added to the `lint` script so a stray `console.*` (or
  any new warning) fails CI instead of accumulating again.

No `Diagnostics.ts` is added or kept.

## Verification

- `npm run lint` → `0 problems` (now with `--max-warnings 0`); guard proven to
  fail a planted `console.log`.
- `npm run compile` → clean webpack build.
- `npm test` → 16 suites, 520/520 passing (incl. a new `StoreUser.safeState`
  test).

## Test plan

- [x] `npm run lint`
- [x] `npm run compile`
- [x] `npm test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017xVwR7VLmfJPnnnGeJkhpT
