### PR TITLE
feat: show "What's New" (Welcome tab) on extension update

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ For Firefox, or to sideload an unpacked build on any supported browser, use the 
 
 > Officially supported browsers: Chrome, Firefox, Edge Chromium. Other Chromium/Gecko variants may work but are not tested.
 
+## release
+
+  npm run build:chrome           # no bump:    1.0.0 → 1.0.0
+  npm run build:chrome patch     # patch bump: 1.0.0 → 1.0.1
+  npm run build:chrome minor     # minor bump: 1.0.0 → 1.1.0
+  npm run build:chrome major     # major bump: 1.0.0 → 2.0.0
+
 ## Attribution
 
 This project is distributed under the MIT License (see [`LICENSE`](LICENSE)). It builds on prior MIT-licensed work whose original copyright notices are retained in the [`LICENSE`](LICENSE) file and in every source file's header, alongside this fork's copyright (© 2026 Vasilis Plavos).

--- a/README.md
+++ b/README.md
@@ -44,12 +44,14 @@ For Firefox, or to sideload an unpacked build on any supported browser, use the 
 
 > **Officially supported: Google Chrome only.** Chrome is the only browser that is actively maintained and tested (via the Chrome Web Store). Other Chromium browsers (Edge, Brave, Vivaldi, Opera, …) can install the same extension from the Web Store and it will likely work, but they are **not supported**. A Firefox `.xpi` build is published on GitHub Releases for those who want it, but it is unsigned and unsupported.
 
-## release
+## Release
 
-  npm run build:chrome           # no bump:    1.0.0 → 1.0.0
-  npm run build:chrome patch     # patch bump: 1.0.0 → 1.0.1
-  npm run build:chrome minor     # minor bump: 1.0.0 → 1.1.0
-  npm run build:chrome major     # major bump: 1.0.0 → 2.0.0
+```sh
+npm run build:chrome           # no bump:    1.0.0 → 1.0.0
+npm run build:chrome patch     # patch bump: 1.0.0 → 1.0.1
+npm run build:chrome minor     # minor bump: 1.0.0 → 1.1.0
+npm run build:chrome major     # major bump: 1.0.0 → 2.0.0
+```
 
 ## Attribution
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cookie AutoDelete V3
 
-> Cookie AutoDelete V3 brings Manifest V3 support to Chrome 109+, Firefox 115+, and Edge 109+. All prior MV2 functionality is preserved.
+> Cookie AutoDelete V3 brings Manifest V3 support to Chrome 109+, Edge 109+ and other Chromium browsers. Firefox manual / sideload install is also available. All prior MV2 functionality is preserved.
 
 ![Tagged Release Distribution](https://github.com/vasilisplavos/Cookie-AutoDeleteV3/workflows/Tagged%20Release%20Distribution/badge.svg) ![Node.js CI Tests](https://github.com/vasilisplavos/Cookie-AutoDeleteV3/workflows/CI/badge.svg?branch=main)
 
@@ -28,21 +28,21 @@ Control your cookies! This extension is inspired by [Self-Destructing Cookies](h
 
 ## Installation
 
-> **Manifest V3 — version 1.0.0:** Requires Chrome 109+, Firefox 115+, or Edge 109+.
+> **Manifest V3 — version 1.0.0:** Requires Chrome 109+, Edge 109+, or any Chromium 109+ browser.
 
-### Chrome & Edge (recommended)
+### Chrome, Edge and any Chromium browser (recommended)
 
-Install directly from the **[Chrome Web Store](https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd)**. Edge users can install Chrome Web Store extensions after enabling "Allow extensions from other stores" in `edge://extensions`.
+Install directly from the **[Chrome Web Store](https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd)**. Other Chromium browsers can install the same extension from the Web Store (Edge requires enabling "Allow extensions from other stores" in `edge://extensions`), but **only Chrome is officially supported**.
 
 ### Firefox & manual install (GitHub Releases)
 
 For Firefox, or to sideload an unpacked build on any supported browser, use the [GitHub Releases](https://github.com/vasilisplavos/Cookie-AutoDeleteV3/releases) artifacts:
 
 1. Download the latest `Cookie-AutoDelete-V3_<version>_Chrome.zip` (or `_Firefox.xpi`) from [Releases](https://github.com/vasilisplavos/Cookie-AutoDeleteV3/releases).
-2. **Chrome / Edge:** extract the zip, open `chrome://extensions` (or `edge://extensions`), enable Developer Mode, click "Load unpacked", and select the extracted folder.
-3. **Firefox:** open `about:debugging#/runtime/this-firefox`, click "Load Temporary Add-on", and select the `.xpi` file. (Note: temporary add-ons are removed when Firefox restarts — for a permanent install, use the `.xpi` via a signed self-distribution channel.)
+2. **Chrome / Edge / Any Chromium browser:** extract the zip, open `chrome://extensions` (or `edge://extensions`, etc.), enable Developer Mode, click "Load unpacked", and select the extracted folder.
+3. **Firefox Nightly:** the `.xpi` is unsigned, so it only installs on Firefox Nightly. Open `about:debugging#/runtime/this-firefox`, click "Load Temporary Add-on", and select the `.xpi` file. (Note: temporary add-ons are removed when Firefox restarts.)
 
-> Officially supported browsers: Chrome, Firefox, Edge Chromium. Other Chromium/Gecko variants may work but are not tested.
+> **Officially supported: Google Chrome only.** Chrome is the only browser that is actively maintained and tested (via the Chrome Web Store). Other Chromium browsers (Edge, Brave, Vivaldi, Opera, …) can install the same extension from the Web Store and it will likely work, but they are **not supported**. A Firefox `.xpi` build is published on GitHub Releases for those who want it, but it is unsigned and unsupported.
 
 ## release
 

--- a/__tests__/background/whatsNew.spec.ts
+++ b/__tests__/background/whatsNew.spec.ts
@@ -1,0 +1,28 @@
+import { openWhatsNewOnUpdate } from '../../src/background/whatsNew';
+import { initialState } from '../../src/redux/State';
+
+const stateWith = (disabled: boolean): State =>
+  ({
+    ...initialState,
+    settings: {
+      ...initialState.settings,
+      [SettingID.DISABLE_NEW_VERSION_POPUP]: {
+        name: SettingID.DISABLE_NEW_VERSION_POPUP,
+        value: disabled,
+      },
+    },
+  } as State);
+
+describe('openWhatsNewOnUpdate', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it('opens the options page when the disable setting is off (default)', async () => {
+    await openWhatsNewOnUpdate(stateWith(false));
+    expect(global.browser.runtime.openOptionsPage).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not open the options page when the disable setting is on', async () => {
+    await openWhatsNewOnUpdate(stateWith(true));
+    expect(global.browser.runtime.openOptionsPage).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/redux/Actions.spec.ts
+++ b/__tests__/redux/Actions.spec.ts
@@ -1,0 +1,48 @@
+/**
+ * Copyright (c) 2022 CAD Team (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/graphs/contributors)
+ * Copyright (c) 2026 Vasilis Plavos
+ * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+import { Store } from 'redux';
+import * as Actions from '../../src/redux/Actions';
+import { initialState } from '../../src/redux/State';
+// tslint:disable-next-line: import-name
+import createStore from '../../src/redux/Store';
+import { ReduxAction } from '../../src/typings/ReduxConstants';
+
+describe('validateSettings', () => {
+  it('adds a missing setting even when the key count is unchanged (swap case)', () => {
+    // Simulate an existing user: same number of settings as initialState, but
+    // missing DISABLE_NEW_VERSION_POPUP and carrying a stale key instead — so
+    // the old count-based guard would have skipped repopulation.
+    // Cast to Record so `delete` and the arbitrary stale key type-check.
+    const settings = { ...initialState.settings } as Record<string, Setting>;
+    delete settings[SettingID.DISABLE_NEW_VERSION_POPUP];
+    settings.staleLegacyKey = { name: 'staleLegacyKey', value: true } as Setting;
+
+    const store: Store<State, ReduxAction> = createStore({
+      ...initialState,
+      settings,
+    });
+    expect(
+      store.getState().settings[SettingID.DISABLE_NEW_VERSION_POPUP],
+    ).toBeUndefined();
+
+    store.dispatch<any>(Actions.validateSettings());
+
+    expect(
+      store.getState().settings[SettingID.DISABLE_NEW_VERSION_POPUP],
+    ).toEqual({
+      name: SettingID.DISABLE_NEW_VERSION_POPUP,
+      value: false,
+    });
+  });
+});

--- a/extension/_locales/el/messages.json
+++ b/extension/_locales/el/messages.json
@@ -55,6 +55,10 @@
     "message": "Συνεισφορά",
     "description": "Contribute"
   },
+  "contributorsPageText": {
+    "message": "Σελίδα συντελεστών",
+    "description": "Link text on the About page pointing to the GitHub contributors graph for the project."
+  },
   "contributorsText": {
     "message": "Συντελεστής",
     "description": "Contributors"
@@ -111,10 +115,6 @@
     "message": "Ενεργοποίηση Greylist Cleanup στην επανεκκίνηση του προγράμματος περιήγησης",
     "description": "Enable Greylist Cleanup on Browser Restart"
   },
-  "enableNewVersionPopup": {
-    "message": "Ενεργοποιήστε το αναδυόμενο παράθυρο όταν κυκλοφορήσει η νέα έκδοση",
-    "description": "Enable Popup when New Version is Released"
-  },
   "errorText": {
     "message": "Σφάλμα! ",
     "description": "Error!"
@@ -150,6 +150,10 @@
   "filterText": {
     "message": "Φίλτρο",
     "description": "Filter"
+  },
+  "firefoxBuildText": {
+    "message": "Έκδοση Mozilla Firefox",
+    "description": "Link text on the About page pointing to the Firefox build on GitHub Releases."
   },
   "greyListWordText": {
     "message": "Greylist",

--- a/extension/_locales/el/messages.json
+++ b/extension/_locales/el/messages.json
@@ -79,6 +79,10 @@
     "message": "Εναλλαγή για απενεργοποίηση του αυτόματου καθαρισμού (χειροκίνητη λειτουργία)",
     "description": "Toggle to disable automatic cleanup (manual mode)"
   },
+  "disableNewVersionPopup": {
+    "message": "Απενεργοποίηση αναδυόμενου παραθύρου όταν κυκλοφορεί νέα έκδοση",
+    "description": "Disable Popup when New Version is Released"
+  },
   "documentationText": {
     "message": "Τεκμηρίωση",
     "description": "Documentation"

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -297,6 +297,10 @@
     "message": "Enable Popup when New Version is Released",
     "description": "Enable Popup when New Version is Released"
   },
+  "disableNewVersionPopup": {
+    "message": "Disable Popup when New Version is Released",
+    "description": "Disable Popup when New Version is Released"
+  },
   "errorText": {
     "message": "Error!",
     "description": "Error!"

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -257,6 +257,10 @@
     "message": "Toggle to disable automatic cleanup (manual mode)",
     "description": "Toggle to disable automatic cleanup (manual mode)"
   },
+  "disableNewVersionPopup": {
+    "message": "Disable Popup when New Version is Released",
+    "description": "Disable Popup when New Version is Released"
+  },
   "documentationText": {
     "message": "Documentation",
     "description": "Documentation"
@@ -296,10 +300,6 @@
   "enableNewVersionPopup": {
     "message": "Enable Popup when New Version is Released",
     "description": "Enable Popup when New Version is Released"
-  },
-  "disableNewVersionPopup": {
-    "message": "Disable Popup when New Version is Released",
-    "description": "Disable Popup when New Version is Released"
   },
   "errorText": {
     "message": "Error!",

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -175,6 +175,10 @@
     "message": "Contribute",
     "description": "Contribute"
   },
+  "contributorsPageText": {
+    "message": "Contributors page",
+    "description": "Link text on the About page pointing to the GitHub contributors graph for the project."
+  },
   "contributorsText": {
     "message": "Contributors",
     "description": "Contributors"
@@ -336,6 +340,10 @@
   "filterText": {
     "message": "Filter",
     "description": "Filter"
+  },
+  "firefoxBuildText": {
+    "message": "Mozilla Firefox build",
+    "description": ""
   },
   "greyListWordText": {
     "message": "Greylist",

--- a/extension/_locales/en/messages.json
+++ b/extension/_locales/en/messages.json
@@ -301,10 +301,6 @@
     "message": "Enable Greylist Cleanup on Browser Restart",
     "description": "Enable Greylist Cleanup on Browser Restart"
   },
-  "enableNewVersionPopup": {
-    "message": "Enable Popup when New Version is Released",
-    "description": "Enable Popup when New Version is Released"
-  },
   "errorText": {
     "message": "Error!",
     "description": "Error!"
@@ -343,7 +339,7 @@
   },
   "firefoxBuildText": {
     "message": "Mozilla Firefox build",
-    "description": ""
+    "description": "Link text on the About page pointing to the Firefox build on GitHub Releases."
   },
   "greyListWordText": {
     "message": "Greylist",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "default_locale": "en",
   "homepage_url": "https://github.com/vasilisplavos/Cookie-AutoDeleteV3",
   "author": "Vasilis Plavos",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "default_locale": "en",
   "homepage_url": "https://github.com/vasilisplavos/Cookie-AutoDeleteV3",
   "author": "Vasilis Plavos",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-autodelete-v3",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "Chrome browser extension that auto-deletes unwanted cookies and site data",
   "keywords": [
     "cookie",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "cookie-autodelete-v3",
   "version": "1.0.7",
-  "description": "Firefox and Chrome browser extension that manages Cookies and other site data",
+  "description": "Chrome browser extension that auto-deletes unwanted cookies and site data",
   "keywords": [
     "cookie",
     "browser cookies",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-autodelete-v3",
-  "version": "1.0.3",
+  "version": "1.0.7",
   "description": "Firefox and Chrome browser extension that manages Cookies and other site data",
   "keywords": [
     "cookie",
@@ -11,8 +11,7 @@
   ],
   "scripts": {
     "build": "npm run compile && node ./tools/buildFilesDev.js",
-    "prebuild:chrome": "node ./tools/bumpVersion.js",
-    "build:chrome": "npm run compile && node ./tools/buildFilesDev.js --target=chrome",
+    "build:chrome": "node ./tools/buildChrome.js",
     "build:firefox": "npm run compile && node ./tools/buildFilesDev.js --target=firefox",
     "compile": "webpack --config webpack.config.js --color",
     "dev": "webpack --config webpack.config.js --progress --color --watch",

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -21,6 +21,7 @@ import {
 } from '../services/Libs';
 import { ReduxConstants } from '../typings/ReduxConstants';
 import { flushSave, getStore, ready } from './lifecycle';
+import { openWhatsNewOnUpdate } from './whatsNew';
 
 // --- Tabs ---
 
@@ -144,9 +145,7 @@ browser.runtime.onInstalled.addListener(async (details) => {
       if (convertVersionToNumber(details.previousVersion) < 300) {
         store.dispatch({ type: ReduxConstants.RESET_COOKIE_DELETED_COUNTER });
       }
-      if (getSetting(store.getState(), SettingID.ENABLE_NEW_POPUP)) {
-        await browser.runtime.openOptionsPage();
-      }
+      await openWhatsNewOnUpdate(store.getState());
       break;
     default:
       break;

--- a/src/background/whatsNew.ts
+++ b/src/background/whatsNew.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright (c) 2026 Vasilis Plavos
+ * Licensed under MIT (https://github.com/Cookie-AutoDelete/Cookie-AutoDelete/blob/3.X.X-Branch/LICENSE)
+ */
+import { getSetting } from '../services/Libs';
+
+/**
+ * Opens the Welcome tab (the options page) after an extension update, unless
+ * the user opted out via SettingID.DISABLE_NEW_VERSION_POPUP.
+ */
+export async function openWhatsNewOnUpdate(state: State): Promise<void> {
+  if (!getSetting(state, SettingID.DISABLE_NEW_VERSION_POPUP)) {
+    await browser.runtime.openOptionsPage();
+  }
+}

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -260,17 +260,16 @@ export const validateSettings: ActionCreator<ThunkAction<
     }
   });
 
-  // Missing a setting
-  if (settingKeys.length !== initialSettingKeys.length) {
-    initialSettingKeys.forEach((k) => {
-      if (settings[k] === undefined) {
-        dispatch({
-          payload: initialSettings[k],
-          type: ReduxConstants.UPDATE_SETTING,
-        });
-      }
-    });
-  }
+  // Add any setting missing from the stored state (e.g. a newly introduced
+  // setting, or one that replaced another so the key count did not change).
+  initialSettingKeys.forEach((k) => {
+    if (settings[k] === undefined) {
+      dispatch({
+        payload: initialSettings[k],
+        type: ReduxConstants.UPDATE_SETTING,
+      });
+    }
+  });
 
   function disableSettingIfTrue(s: Setting) {
     if (s && s.value) {

--- a/src/redux/State.ts
+++ b/src/redux/State.ts
@@ -67,10 +67,6 @@ export const initialState: State = {
       name: SettingID.ENABLE_GREYLIST,
       value: true,
     },
-    [SettingID.ENABLE_NEW_POPUP]: {
-      name: SettingID.ENABLE_NEW_POPUP,
-      value: false,
-    },
     [SettingID.DISABLE_NEW_VERSION_POPUP]: {
       name: SettingID.DISABLE_NEW_VERSION_POPUP,
       value: false,

--- a/src/redux/State.ts
+++ b/src/redux/State.ts
@@ -71,6 +71,10 @@ export const initialState: State = {
       name: SettingID.ENABLE_NEW_POPUP,
       value: false,
     },
+    [SettingID.DISABLE_NEW_VERSION_POPUP]: {
+      name: SettingID.DISABLE_NEW_VERSION_POPUP,
+      value: false,
+    },
     [SettingID.OLD_GREY_CLEAN_LOCALSTORAGE]: {
       id: 'DEPRECATED - use default expressions',
       name: SettingID.OLD_GREY_CLEAN_LOCALSTORAGE,

--- a/src/typings/Global.d.ts
+++ b/src/typings/Global.d.ts
@@ -99,6 +99,7 @@ declare const enum SettingID {
   DEBUG_MODE = 'debugMode',
   ENABLE_GREYLIST = 'enableGreyListCleanup',
   ENABLE_NEW_POPUP = 'enableNewVersionPopup',
+  DISABLE_NEW_VERSION_POPUP = 'disableNewVersionPopup',
   KEEP_DEFAULT_ICON = 'keepDefaultIcon',
   NOTIFY_AUTO = 'showNotificationAfterCleanup',
   NOTIFY_MANUAL = 'manualNotifications',

--- a/src/typings/Global.d.ts
+++ b/src/typings/Global.d.ts
@@ -98,7 +98,6 @@ declare const enum SettingID {
   CONTEXTUAL_IDENTITIES_AUTOREMOVE = 'contextualIdentitiesAutoRemove',
   DEBUG_MODE = 'debugMode',
   ENABLE_GREYLIST = 'enableGreyListCleanup',
-  ENABLE_NEW_POPUP = 'enableNewVersionPopup',
   DISABLE_NEW_VERSION_POPUP = 'disableNewVersionPopup',
   KEEP_DEFAULT_ICON = 'keepDefaultIcon',
   NOTIFY_AUTO = 'showNotificationAfterCleanup',

--- a/src/ui/settings/components/About.tsx
+++ b/src/ui/settings/components/About.tsx
@@ -64,6 +64,7 @@ const settingOrder = [
   SettingID.NOTIFY_AUTO,
   SettingID.NOTIFY_MANUAL,
   SettingID.NOTIFY_DURATION,
+  SettingID.DISABLE_NEW_VERSION_POPUP,
   SettingID.SIZE_POPUP,
   SettingID.SIZE_SETTING,
   SettingID.CONTEXT_MENUS,
@@ -97,15 +98,31 @@ class About extends React.Component<AboutProps> {
         </a>
         <br />
         <br />{' '}
-        <a href="https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd" target="_blank" rel="noreferrer">
-          <span>{`${browser.i18n.getMessage('versionText', ['Google Chrome',])}`}</span>{' '}
+        <a
+          href="https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <span>{`${browser.i18n.getMessage('versionText', [
+            'Google Chrome',
+          ])}`}</span>{' '}
         </a>
         <br />
-        <a href="https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd" target="_blank" rel="noreferrer">
-          <span>{`${browser.i18n.getMessage('versionText', ['Microsoft Edge and other Chromium-based browsers',])}`}</span>{' '}
+        <a
+          href="https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd"
+          target="_blank"
+          rel="noreferrer"
+        >
+          <span>{`${browser.i18n.getMessage('versionText', [
+            'Microsoft Edge and other Chromium-based browsers',
+          ])}`}</span>{' '}
         </a>{' '}
         <br />
-        <a href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/releases" target="_blank" rel="noreferrer">
+        <a
+          href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/releases"
+          target="_blank"
+          rel="noreferrer"
+        >
           <span>{`${browser.i18n.getMessage('firefoxBuildText')}`}</span>{' '}
         </a>{' '}
         <br />
@@ -113,7 +130,11 @@ class About extends React.Component<AboutProps> {
         <span>{`${browser.i18n.getMessage('contributorsText')}`}:</span>
         <ul>
           <li>
-            <a href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/graphs/contributors" target="_blank" rel="noreferrer"            >
+            <a
+              href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/graphs/contributors"
+              target="_blank"
+              rel="noreferrer"
+            >
               {`${browser.i18n.getMessage('contributorsPageText')}`}
             </a>
           </li>
@@ -133,12 +154,15 @@ class About extends React.Component<AboutProps> {
           readOnly={true}
           style={{ resize: 'none' }}
         >
-          {`- OS: ${platformInfo.arch} ${platformOS[platformInfo.os]
-            } (Please add OS version on paste)\n- Browser Info: ${bName} ${isFirefox(cache)
+          {`- OS: ${platformInfo.arch} ${
+            platformOS[platformInfo.os]
+          } (Please add OS version on paste)\n- Browser Info: ${bName} ${
+            isFirefox(cache)
               ? `${cache.browserVersion} (${cache.browserInfo.buildID})`
               : `(Please add version number on paste)`
-            }\n- CookieAutoDelete Version: ${browser.runtime.getManifest().version
-            }`}
+          }\n- CookieAutoDelete Version: ${
+            browser.runtime.getManifest().version
+          }`}
         </textarea>
         <br />
         <IconButton

--- a/src/ui/settings/components/About.tsx
+++ b/src/ui/settings/components/About.tsx
@@ -64,7 +64,6 @@ const settingOrder = [
   SettingID.NOTIFY_AUTO,
   SettingID.NOTIFY_MANUAL,
   SettingID.NOTIFY_DURATION,
-  SettingID.ENABLE_NEW_POPUP,
   SettingID.SIZE_POPUP,
   SettingID.SIZE_SETTING,
   SettingID.CONTEXT_MENUS,

--- a/src/ui/settings/components/About.tsx
+++ b/src/ui/settings/components/About.tsx
@@ -97,41 +97,28 @@ class About extends React.Component<AboutProps> {
         </a>
         <br />
         <br />{' '}
-        <a
-          href="https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <span>{`${browser.i18n.getMessage('versionText', [
-            'Google Chrome',
-          ])}`}</span>{' '}
+        <a href="https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd" target="_blank" rel="noreferrer">
+          <span>{`${browser.i18n.getMessage('versionText', ['Google Chrome',])}`}</span>{' '}
         </a>
         <br />
-        <a
-          href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/releases"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <span>{`${browser.i18n.getMessage('versionText', [
-            'Microsoft Edge Chromium',
-          ])}`}</span>{' '}
+        <a href="https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd" target="_blank" rel="noreferrer">
+          <span>{`${browser.i18n.getMessage('versionText', ['Microsoft Edge and other Chromium-based browsers',])}`}</span>{' '}
         </a>{' '}
         <br />
-        <a
-          href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/releases"
-          target="_blank"
-          rel="noreferrer"
-        >
-          <span>{`${browser.i18n.getMessage('versionText', [
-            'Mozilla Firefox',
-          ])}`}</span>{' '}
+        <a href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/releases" target="_blank" rel="noreferrer">
+          <span>{`${browser.i18n.getMessage('firefoxBuildText')}`}</span>{' '}
         </a>{' '}
         <br />
         <br />
         <span>{`${browser.i18n.getMessage('contributorsText')}`}:</span>
         <ul>
           <li>
-            <a href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/graphs/contributors">
+            <a href="https://github.com/vasilisplavos/Cookie-AutoDeleteV3/graphs/contributors" target="_blank" rel="noreferrer"            >
+              {`${browser.i18n.getMessage('contributorsPageText')}`}
+            </a>
+          </li>
+          <li>
+            <a href="https://plavos.com/dev" target="_blank" rel="noreferrer">
               Vasilis Plavos
             </a>
           </li>
@@ -146,15 +133,12 @@ class About extends React.Component<AboutProps> {
           readOnly={true}
           style={{ resize: 'none' }}
         >
-          {`- OS: ${platformInfo.arch} ${
-            platformOS[platformInfo.os]
-          } (Please add OS version on paste)\n- Browser Info: ${bName} ${
-            isFirefox(cache)
+          {`- OS: ${platformInfo.arch} ${platformOS[platformInfo.os]
+            } (Please add OS version on paste)\n- Browser Info: ${bName} ${isFirefox(cache)
               ? `${cache.browserVersion} (${cache.browserInfo.buildID})`
               : `(Please add version number on paste)`
-          }\n- CookieAutoDelete Version: ${
-            browser.runtime.getManifest().version
-          }`}
+            }\n- CookieAutoDelete Version: ${browser.runtime.getManifest().version
+            }`}
         </textarea>
         <br />
         <IconButton

--- a/src/ui/settings/components/Settings.tsx
+++ b/src/ui/settings/components/Settings.tsx
@@ -606,17 +606,6 @@ class Settings extends React.Component<SettingProps> {
             <SettingsTooltip hrefURL={'#duration-for-notifications'} />
           </div>
           <div className="form-group">
-            <CheckboxSetting
-              text={browser.i18n.getMessage(SettingID.ENABLE_NEW_POPUP)}
-              settingObject={settings[SettingID.ENABLE_NEW_POPUP]}
-              inline={true}
-              updateSetting={(payload) => onUpdateSetting(payload)}
-            />
-            <SettingsTooltip
-              hrefURL={'#enable-popup-when-new-version-is-released'}
-            />
-          </div>
-          <div className="form-group">
             <SelectInput
               numSize={14}
               numStart={10}

--- a/src/ui/settings/components/Welcome.tsx
+++ b/src/ui/settings/components/Welcome.tsx
@@ -53,7 +53,6 @@ const getReviewLink = (bName: browserName = browserDetect() as browserName) => {
     case browserName.Chrome:
       return 'https://chromewebstore.google.com/detail/cookie-autodelete-v3/jofioghmpdcgiiobkhmdojhjbjiejfbd/reviews';
     case browserName.EdgeChromium:
-      return 'https://github.com/vasilisplavos/Cookie-AutoDeleteV3/releases';
     case browserName.Firefox:
       return 'https://github.com/vasilisplavos/Cookie-AutoDeleteV3/releases';
     default:
@@ -152,8 +151,12 @@ const mapDispatchToProps = (dispatch: Dispatch<ReduxAction>) => ({
 });
 
 const mapStateToProps = (state: State) => {
-  const { cookieDeletedCounterTotal, cookieDeletedCounterSession, cache, settings } =
-    state;
+  const {
+    cookieDeletedCounterTotal,
+    cookieDeletedCounterSession,
+    cache,
+    settings,
+  } = state;
   return {
     bName: cache.browserDetect || (browserDetect() as browserName),
     cookieDeletedCounterSession,

--- a/src/ui/settings/components/Welcome.tsx
+++ b/src/ui/settings/components/Welcome.tsx
@@ -17,8 +17,12 @@ import { Dispatch } from 'redux';
 // tslint:disable-next-line: import-name
 import ReleaseNotes from '../ReleaseNotes.json';
 import IconButton from '../../common_components/IconButton';
+import CheckboxSetting from '../../common_components/CheckboxSetting';
 import { ReduxAction } from '../../../typings/ReduxConstants';
-import { resetCookieDeletedCounter } from '../../../redux/Actions';
+import {
+  resetCookieDeletedCounter,
+  updateSetting,
+} from '../../../redux/Actions';
 
 const displayReleaseNotes = (releases: ReleaseNote[]) => {
   return (
@@ -62,10 +66,12 @@ interface OwnProps {
   cookieDeletedCounterSession: number;
   cookieDeletedCounterTotal: number;
   bName: browserName;
+  settings: MapToSettingObject;
 }
 
 interface DispatchProps {
   onResetCounterButtonClick: () => void;
+  onUpdateSetting: (payload: Setting) => void;
 }
 
 type WelcomeProps = OwnProps & DispatchProps;
@@ -75,7 +81,9 @@ const Welcome: React.FunctionComponent<WelcomeProps> = ({
   cookieDeletedCounterTotal,
   cookieDeletedCounterSession,
   bName,
+  settings,
   onResetCounterButtonClick,
+  onUpdateSetting,
 }) => {
   const { releases } = ReleaseNotes as { releases: ReleaseNote[] };
   return (
@@ -110,6 +118,15 @@ const Welcome: React.FunctionComponent<WelcomeProps> = ({
       <hr />
       <h2>{browser.i18n.getMessage('releaseNotesText')}</h2>
 
+      <div className="form-group">
+        <CheckboxSetting
+          text={browser.i18n.getMessage(SettingID.DISABLE_NEW_VERSION_POPUP)}
+          settingObject={settings[SettingID.DISABLE_NEW_VERSION_POPUP]}
+          inline={true}
+          updateSetting={(payload) => onUpdateSetting(payload)}
+        />
+      </div>
+
       <div className="row">{displayReleaseNotes(releases.slice(0, 5))}</div>
       <p>
         {browser.i18n.getMessage('oldReleasesText')}{' '}
@@ -129,15 +146,19 @@ const mapDispatchToProps = (dispatch: Dispatch<ReduxAction>) => ({
   onResetCounterButtonClick() {
     dispatch(resetCookieDeletedCounter());
   },
+  onUpdateSetting(payload: Setting) {
+    dispatch(updateSetting(payload));
+  },
 });
 
 const mapStateToProps = (state: State) => {
-  const { cookieDeletedCounterTotal, cookieDeletedCounterSession, cache } =
+  const { cookieDeletedCounterTotal, cookieDeletedCounterSession, cache, settings } =
     state;
   return {
     bName: cache.browserDetect || (browserDetect() as browserName),
     cookieDeletedCounterSession,
     cookieDeletedCounterTotal,
+    settings,
   };
 };
 

--- a/tools/buildChrome.js
+++ b/tools/buildChrome.js
@@ -1,0 +1,21 @@
+/**
+ * Chrome build entry point.
+ *
+ * Optionally bumps the version, then compiles and packages the Chrome build.
+ * The bump type is passed positionally (npm forwards it to this script):
+ *
+ *   npm run build:chrome          # no bump:    1.0.0 -> 1.0.0
+ *   npm run build:chrome patch    # patch bump: 1.0.0 -> 1.0.1
+ *   npm run build:chrome minor    # minor bump: 1.0.0 -> 1.1.0
+ *   npm run build:chrome major    # major bump: 1.0.0 -> 2.0.0
+ *
+ * The bump must happen before packaging so the built .zip carries the new
+ * version. package.json is the source of truth (see tools/bumpVersion.js).
+ */
+const { execSync } = require('child_process');
+const { bumpVersion } = require('./bumpVersion');
+
+bumpVersion(process.argv[2]);
+
+execSync('npm run compile', { stdio: 'inherit' });
+execSync('node ./tools/buildFilesDev.js --target=chrome', { stdio: 'inherit' });

--- a/tools/bumpVersion.js
+++ b/tools/bumpVersion.js
@@ -1,40 +1,94 @@
 /**
- * Auto-increments the patch component of the version (X.Y.Z -> X.Y.Z+1) in
- * both extension/manifest.json and package.json, keeping them in sync.
+ * Version bumper for the Chrome build pipeline.
  *
- * Wired as the "prebuild:chrome" npm hook, so it runs automatically before
- * every `npm run build:chrome`, guaranteeing each Chrome build has a higher
- * version than the last (which the Chrome Web Store requires for updates).
+ * package.json is the source of truth for the current version (matching
+ * tools/replaceVersionNumber.js and the release workflows). The release type
+ * is chosen by the caller:
  *
- * Only the version string is rewritten; the rest of each file (formatting,
- * key order) is left untouched.
+ *   bumpVersion()          -> no bump; only re-syncs manifest.json to package.json
+ *   bumpVersion('patch')   -> X.Y.Z -> X.Y.(Z+1)
+ *   bumpVersion('minor')   -> X.Y.Z -> X.(Y+1).0
+ *   bumpVersion('major')   -> X.Y.Z -> (X+1).0.0
+ *
+ * The resulting version is written to BOTH package.json and
+ * extension/manifest.json, keeping them in sync. Only the version string is
+ * rewritten; the rest of each file (formatting, key order) is left untouched.
+ *
+ * Exposed as a function (used by tools/buildChrome.js) and runnable directly:
+ *   node ./tools/bumpVersion.js [patch|minor|major]
  */
 const fs = require('fs');
 const path = require('path');
 
 const ROOT = process.cwd();
-const FILES = [
-  path.join(ROOT, 'extension', 'manifest.json'),
-  path.join(ROOT, 'package.json'),
-];
+const PACKAGE_JSON = path.join(ROOT, 'package.json');
+const MANIFEST_JSON = path.join(ROOT, 'extension', 'manifest.json');
 const VERSION_RE = /("version"\s*:\s*")(\d+)\.(\d+)\.(\d+)(")/;
+const RELEASE_TYPES = ['patch', 'minor', 'major'];
 
-const manifestTxt = fs.readFileSync(FILES[0], 'utf8');
-const m = VERSION_RE.exec(manifestTxt);
-if (!m) {
-  console.error('ERROR: could not find a "version": "X.Y.Z" field in manifest.json');
-  process.exit(1);
+function computeNext(version, releaseType) {
+  const [major, minor, patch] = version.split('.').map((n) => parseInt(n, 10));
+  switch (releaseType) {
+    case 'major':
+      return `${major + 1}.0.0`;
+    case 'minor':
+      return `${major}.${minor + 1}.0`;
+    case 'patch':
+      return `${major}.${minor}.${patch + 1}`;
+    default:
+      return version; // no bump
+  }
 }
 
-const next = `${m[2]}.${m[3]}.${parseInt(m[4], 10) + 1}`;
+function readVersion(fp) {
+  const m = VERSION_RE.exec(fs.readFileSync(fp, 'utf8'));
+  return m ? `${m[2]}.${m[3]}.${m[4]}` : null;
+}
 
-for (const fp of FILES) {
+function writeVersion(fp, version) {
   const txt = fs.readFileSync(fp, 'utf8');
   if (!VERSION_RE.test(txt)) {
     console.warn(`WARN: no version field found in ${path.basename(fp)}, skipping.`);
-    continue;
+    return;
   }
-  fs.writeFileSync(fp, txt.replace(VERSION_RE, `$1${next}$5`));
+  fs.writeFileSync(fp, txt.replace(VERSION_RE, `$1${version}$5`));
 }
 
-console.log(`Version bumped to ${next}`);
+/**
+ * @param {string|undefined} releaseType 'patch' | 'minor' | 'major' | undefined
+ * @returns {string} the resulting version
+ */
+function bumpVersion(releaseType) {
+  if (releaseType && !RELEASE_TYPES.includes(releaseType)) {
+    console.error(
+      `ERROR: unknown release type "${releaseType}". Use one of: ${RELEASE_TYPES.join(
+        ', ',
+      )} (or omit for no bump).`,
+    );
+    process.exit(1);
+  }
+
+  const current = readVersion(PACKAGE_JSON);
+  if (!current) {
+    console.error('ERROR: could not find a "version": "X.Y.Z" field in package.json');
+    process.exit(1);
+  }
+
+  const next = computeNext(current, releaseType);
+
+  writeVersion(PACKAGE_JSON, next);
+  writeVersion(MANIFEST_JSON, next);
+
+  if (next === current) {
+    console.log(`Version unchanged at ${next} (manifest.json synced to package.json).`);
+  } else {
+    console.log(`Version bumped ${current} -> ${next} (${releaseType}).`);
+  }
+  return next;
+}
+
+module.exports = { bumpVersion, computeNext };
+
+if (require.main === module) {
+  bumpVersion(process.argv[2]);
+}

--- a/tools/bumpVersion.js
+++ b/tools/bumpVersion.js
@@ -48,7 +48,9 @@ function readVersion(fp) {
 function writeVersion(fp, version) {
   const txt = fs.readFileSync(fp, 'utf8');
   if (!VERSION_RE.test(txt)) {
-    console.warn(`WARN: no version field found in ${path.basename(fp)}, skipping.`);
+    console.warn(
+      `WARN: no version field found in ${path.basename(fp)}, skipping.`,
+    );
     return;
   }
   fs.writeFileSync(fp, txt.replace(VERSION_RE, `$1${version}$5`));
@@ -70,7 +72,9 @@ function bumpVersion(releaseType) {
 
   const current = readVersion(PACKAGE_JSON);
   if (!current) {
-    console.error('ERROR: could not find a "version": "X.Y.Z" field in package.json');
+    console.error(
+      'ERROR: could not find a "version": "X.Y.Z" field in package.json',
+    );
     process.exit(1);
   }
 
@@ -80,7 +84,9 @@ function bumpVersion(releaseType) {
   writeVersion(MANIFEST_JSON, next);
 
   if (next === current) {
-    console.log(`Version unchanged at ${next} (manifest.json synced to package.json).`);
+    console.log(
+      `Version unchanged at ${next} (manifest.json synced to package.json).`,
+    );
   } else {
     console.log(`Version bumped ${current} -> ${next} (${releaseType}).`);
   }


### PR DESCRIPTION
## Summary

When the extension is updated in a user's browser, it now **automatically opens the Welcome tab** (which already renders the Release Notes) so users can see what changed. This is **on by default** — including for existing users — with an **opt-out checkbox moved onto the Welcome page** itself.

Previously, an update only opened anything if an obscure, default-off setting (`ENABLE_NEW_POPUP` / "Enable Popup when New Version is Released") happened to be on, so almost nobody ever saw release notes after an update.

## What changed

- **Behavior** (`src/background/index.ts`): the `onInstalled` `update` branch now opens the Welcome tab via a small, testable helper `openWhatsNewOnUpdate(state)` — unless the user opted out. Fresh-`install` behavior is unchanged.
- **Setting — inverted to opt-out** (`src/typings/Global.d.ts`, `src/redux/State.ts`): introduced `disableNewVersionPopup` (default `false` = shown). `value === true` ⇒ the popup is suppressed. The obsolete `enableNewVersionPopup` setting is retired.
- **`validateSettings` fix** (`src/redux/Actions.ts`): the "missing setting" repopulation was gated on a **key-count** mismatch, which silently skipped the case where one setting is swapped for another (equal count). It now runs unconditionally, so **existing users** reliably receive the new key with its default before it is read. (`getSetting` throws on a missing key, so this ordering is load-bearing.)
- **UI** (`Welcome.tsx`, `Settings.tsx`, `About.tsx`): the opt-out checkbox — relabelled **"Disable Popup when New Version is Released"** — now lives on the Welcome page next to the Release Notes, and was removed from the Settings tab.
- **i18n**: added the `disableNewVersionPopup` label to `en` (fallback) and `el`; other locales fall back to `en`.

## Post-review cleanup

Follow-up commit addressing a code review (dead code / dead conditionals / lint):

- **Dead i18n key removed**: the retired `enableNewVersionPopup` message is deleted from `en`/`el` (nothing references it after the rename).
- **i18n gaps fixed** (`el`): added the `contributorsPageText` and `firefoxBuildText` translations that `About.tsx` newly references (they were silently falling back to English).
- **Debug export fix** (`About.tsx`): `settingOrder` dropped `ENABLE_NEW_POPUP` without adding its replacement, so the "Copy Settings" debug dump omitted the new setting — `DISABLE_NEW_VERSION_POPUP` is restored.
- **Dead conditional collapsed** (`Welcome.tsx`): `getReviewLink`'s `EdgeChromium` and `Firefox` cases returned the same URL — merged via fall-through.
- **Docs** (`README.md`): the release-command block was 2-space indented (renders as one run-on paragraph on GitHub) — now a fenced code block; heading title-cased.
- **Formatting**: Prettier applied to `About.tsx` / `Welcome.tsx` / `tools/bumpVersion.js` (the branch had collapsed JSX onto over-long lines). `Actions.ts` left untouched — its Prettier deltas are pre-existing, not from this branch.

## Testing

- `npx jest` → **18 suites, 523 tests, all passing** (incl. new `__tests__/redux/Actions.spec.ts` and `__tests__/background/whatsNew.spec.ts`).
- `npm run lint` (eslint, `src/**/*.ts`) → **clean, 0 warnings**; `prettier --check` on the changed files → clean.
- `npm run compile` → clean (no TypeScript errors; only pre-existing bundle-size warnings).
- New tests verify real behavior: the `validateSettings` test drives the actual store/thunk/reducer (asserting the missing key is repopulated in the equal-count swap case); the helper test asserts both branches against the mocked `openOptionsPage`.

### Manual verification (pending — requires loading the unpacked build)

- [ ] Load unpacked (`extension/`), open **Options** → the "Disable Popup…" checkbox is on the **Welcome** tab (not Settings).
- [ ] Bump `manifest.json` `version` and reload the unpacked entry → a tab opens on the Welcome page.
- [ ] Check the box, bump+reload again → the tab does **not** open. (Revert the temporary version bump.)

## Out of scope

- No new dedicated "What's New" tab/page — the existing Welcome tab is reused.
- Release Notes are not filtered to "since the previous version".
- The obsolete `enableNewVersionPopup` message string still lingers in **26 other locale files** (not touched by this branch); it is dead everywhere and can be swept in a separate cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TwPGcvWc3kFtVqqGHHPJMN
