### PR TITLE
feat(#69): clean non-cookie site data on startup via visited-domain registry

### DIFF
--- a/__tests__/redux/Actions.spec.ts
+++ b/__tests__/redux/Actions.spec.ts
@@ -11,12 +11,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+import { when } from 'jest-when';
 import { Store } from 'redux';
 import * as Actions from '../../src/redux/Actions';
 import { initialState } from '../../src/redux/State';
 // tslint:disable-next-line: import-name
 import createStore from '../../src/redux/Store';
+import * as CleanupService from '../../src/services/CleanupService';
 import { ReduxAction } from '../../src/typings/ReduxConstants';
+
+const spyCleanupService: JestSpyObject = global.generateSpies(CleanupService);
 
 describe('validateSettings', () => {
   it('adds a missing setting even when the key count is unchanged (swap case)', () => {
@@ -44,5 +48,48 @@ describe('validateSettings', () => {
       name: SettingID.DISABLE_NEW_VERSION_POPUP,
       value: false,
     });
+  });
+});
+
+describe('cookieCleanup', () => {
+  beforeEach(() => {
+    when(spyCleanupService.cleanCookiesOperation)
+      .calledWith(expect.any(Object), expect.any(Object))
+      .mockResolvedValue({
+        setOfDeletedDomainCookies: [],
+        cachedResults: {
+          dateTime: 'now',
+          recentlyCleaned: 0,
+          storeIds: {},
+          browsingDataCleanup: {},
+          siteDataCleaned: false,
+        },
+      } as never);
+  });
+
+  it('clears domainsToClean after a successful startup (greyCleanup) cleanup', async () => {
+    const store: Store<State, ReduxAction> = createStore({
+      ...initialState,
+      domainsToClean: ['a.com', 'b.com'],
+    });
+
+    await store.dispatch<any>(
+      Actions.cookieCleanup({ greyCleanup: true, ignoreOpenTabs: false }),
+    );
+
+    expect(store.getState().domainsToClean).toEqual([]);
+  });
+
+  it('does NOT clear domainsToClean on a non-startup (greyCleanup=false) cleanup', async () => {
+    const store: Store<State, ReduxAction> = createStore({
+      ...initialState,
+      domainsToClean: ['a.com'],
+    });
+
+    await store.dispatch<any>(
+      Actions.cookieCleanup({ greyCleanup: false, ignoreOpenTabs: false }),
+    );
+
+    expect(store.getState().domainsToClean).toEqual(['a.com']);
   });
 });

--- a/__tests__/redux/Reducer.spec.ts
+++ b/__tests__/redux/Reducer.spec.ts
@@ -16,6 +16,7 @@ import {
   cache,
   cookieDeletedCounterSession,
   cookieDeletedCounterTotal,
+  domainsToClean,
   expression,
   expressions,
   lists,
@@ -511,6 +512,46 @@ describe('Reducer', () => {
         type: ReduxConstants.RESET_ALL,
       });
       expect(newState).toEqual({});
+    });
+  });
+
+  describe('domainsToClean', () => {
+    it('should add a new hostname', () => {
+      const result = domainsToClean(['a.com'], {
+        payload: 'b.com',
+        type: ReduxConstants.ADD_DOMAIN_TO_CLEAN,
+      });
+      expect(result).toEqual(['a.com', 'b.com']);
+    });
+
+    it('should not add a duplicate hostname', () => {
+      const result = domainsToClean(['a.com'], {
+        payload: 'a.com',
+        type: ReduxConstants.ADD_DOMAIN_TO_CLEAN,
+      });
+      expect(result).toEqual(['a.com']);
+    });
+
+    it('should not add a blank hostname', () => {
+      const result = domainsToClean([], {
+        payload: '   ',
+        type: ReduxConstants.ADD_DOMAIN_TO_CLEAN,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('should clear on CLEAR_DOMAINS_TO_CLEAN', () => {
+      const result = domainsToClean(['a.com', 'b.com'], {
+        type: ReduxConstants.CLEAR_DOMAINS_TO_CLEAN,
+      });
+      expect(result).toEqual([]);
+    });
+
+    it('should clear on RESET_ALL', () => {
+      const result = domainsToClean(['a.com'], {
+        type: ReduxConstants.RESET_ALL,
+      });
+      expect(result).toEqual([]);
     });
   });
 

--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -836,6 +836,100 @@ describe('CleanupService', () => {
     });
   });
 
+  describe('cleanCookiesOperation() with domainsToClean registry', () => {
+    const firefoxRegistryState = {
+      ...sampleState,
+      cache: {
+        browserDetect: browserName.Firefox,
+        browserVersion: '77',
+        platformOs: 'desktop',
+      },
+      settings: {
+        ...sampleState.settings,
+        [SettingID.CLEANUP_LOCALSTORAGE]: {
+          name: SettingID.CLEANUP_LOCALSTORAGE,
+          value: true,
+        },
+      },
+      domainsToClean: ['registry-only.com'],
+    };
+
+    beforeEach(() => {
+      when(global.browser.tabs.query)
+        .calledWith(expect.any(Object))
+        .mockResolvedValue([] as never);
+      when(global.browser.extension.isAllowedIncognitoAccess)
+        .calledWith()
+        .mockResolvedValue(false as never);
+      when(global.browser.cookies.getAllCookieStores)
+        .calledWith()
+        .mockResolvedValue([{ id: 'firefox-default' }] as never);
+      when(global.browser.cookies.getAll)
+        .calledWith(expect.any(Object))
+        .mockResolvedValue([] as never);
+      when(global.browser.browsingData.remove)
+        .calledWith(expect.any(Object), expect.any(Object))
+        .mockResolvedValue(undefined as never);
+    });
+
+    it('cleans site data for a registry hostname that left no cookie (startup)', async () => {
+      await cleanCookiesOperation(firefoxRegistryState, {
+        greyCleanup: true,
+        ignoreOpenTabs: false,
+      });
+      const removeCalls = (global.browser.browsingData.remove as jest.Mock).mock
+        .calls;
+      const cleanedHostnames = removeCalls.reduce(
+        (acc: string[], c: unknown[]) =>
+          acc.concat((c[0] as { hostnames?: string[] }).hostnames || []),
+        [] as string[],
+      );
+      expect(cleanedHostnames).toContain('registry-only.com');
+    });
+
+    it('does NOT consume the registry during a non-startup (greyCleanup=false) run', async () => {
+      await cleanCookiesOperation(firefoxRegistryState, {
+        greyCleanup: false,
+        ignoreOpenTabs: false,
+      });
+      const removeCalls = (global.browser.browsingData.remove as jest.Mock).mock
+        .calls;
+      const cleanedHostnames = removeCalls.reduce(
+        (acc: string[], c: unknown[]) =>
+          acc.concat((c[0] as { hostnames?: string[] }).hostnames || []),
+        [] as string[],
+      );
+      expect(cleanedHostnames).not.toContain('registry-only.com');
+    });
+
+    it('does NOT clean a registry hostname that is whitelisted', async () => {
+      const whitelistedState = {
+        ...firefoxRegistryState,
+        lists: {
+          default: [
+            {
+              expression: 'registry-only.com',
+              listType: ListType.WHITE,
+              storeId: 'default',
+            },
+          ],
+        },
+      };
+      await cleanCookiesOperation(whitelistedState, {
+        greyCleanup: true,
+        ignoreOpenTabs: false,
+      });
+      const removeCalls = (global.browser.browsingData.remove as jest.Mock).mock
+        .calls;
+      const cleanedHostnames = removeCalls.reduce(
+        (acc: string[], c: unknown[]) =>
+          acc.concat((c[0] as { hostnames?: string[] }).hostnames || []),
+        [] as string[],
+      );
+      expect(cleanedHostnames).not.toContain('registry-only.com');
+    });
+  });
+
   describe('cleanSiteData()', () => {
     afterEach(() => {
       spyCleanupService.removeSiteData.mockRestore();

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -305,6 +305,32 @@ describe('TabEvents', () => {
       });
       expect(store.getState().domainsToClean).not.toContain('plain.net');
     });
+
+    it('should NOT record the hostname when ACTIVE_MODE is disabled, even if a site-data cleanup is enabled', async () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: 'inactive.net', storeId: 'firefox-default' })
+        .mockResolvedValue([] as never);
+      TestStore.changeSetting(SettingID.CLEANUP_LOCALSTORAGE, true);
+      TestStore.changeSetting(SettingID.ACTIVE_MODE, false);
+      await TabEvents.getAllCookieActions({
+        ...sampleTab,
+        url: 'http://inactive.net',
+      });
+      expect(store.getState().domainsToClean).not.toContain('inactive.net');
+    });
+
+    it('should NOT record the hostname when ENABLE_GREYLIST is disabled, even if a site-data cleanup is enabled', async () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: 'nogreylist.net', storeId: 'firefox-default' })
+        .mockResolvedValue([] as never);
+      TestStore.changeSetting(SettingID.CLEANUP_LOCALSTORAGE, true);
+      TestStore.changeSetting(SettingID.ENABLE_GREYLIST, false);
+      await TabEvents.getAllCookieActions({
+        ...sampleTab,
+        url: 'http://nogreylist.net',
+      });
+      expect(store.getState().domainsToClean).not.toContain('nogreylist.net');
+    });
   });
 
   describe('onTabDiscarded', () => {

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -277,6 +277,34 @@ describe('TabEvents', () => {
         'firstPartyDomain',
       );
     });
+
+    it('should record the hostname in domainsToClean when a site-data cleanup is enabled', async () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: 'nocookie.net', storeId: 'firefox-default' })
+        .mockResolvedValue([] as never);
+      TestStore.changeSetting(SettingID.CLEANUP_LOCALSTORAGE, true);
+      await TabEvents.getAllCookieActions({
+        ...sampleTab,
+        url: 'http://nocookie.net',
+      });
+      expect(store.getState().domainsToClean).toContain('nocookie.net');
+    });
+
+    it('should NOT record the hostname when all site-data cleanups are disabled', async () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: 'plain.net', storeId: 'firefox-default' })
+        .mockResolvedValue([] as never);
+      TestStore.changeSetting(SettingID.CLEANUP_CACHE, false);
+      TestStore.changeSetting(SettingID.CLEANUP_INDEXEDDB, false);
+      TestStore.changeSetting(SettingID.CLEANUP_LOCALSTORAGE, false);
+      TestStore.changeSetting(SettingID.CLEANUP_PLUGINDATA, false);
+      TestStore.changeSetting(SettingID.CLEANUP_SERVICEWORKERS, false);
+      await TabEvents.getAllCookieActions({
+        ...sampleTab,
+        url: 'http://plain.net',
+      });
+      expect(store.getState().domainsToClean).not.toContain('plain.net');
+    });
   });
 
   describe('onTabDiscarded', () => {

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -331,6 +331,24 @@ describe('TabEvents', () => {
       });
       expect(store.getState().domainsToClean).not.toContain('nogreylist.net');
     });
+
+    it('should NOT record the hostname for a Chrome incognito tab (no cookieStoreId, incognito=true)', async () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: 'chromeincognito.net', storeId: undefined })
+        .mockResolvedValue([] as never);
+      TestStore.changeSetting(SettingID.CLEANUP_LOCALSTORAGE, true);
+      TestStore.changeSetting(SettingID.ACTIVE_MODE, true);
+      TestStore.changeSetting(SettingID.ENABLE_GREYLIST, true);
+      await TabEvents.getAllCookieActions({
+        ...sampleTab,
+        cookieStoreId: undefined,
+        incognito: true,
+        url: 'http://chromeincognito.net',
+      });
+      expect(store.getState().domainsToClean).not.toContain(
+        'chromeincognito.net',
+      );
+    });
   });
 
   describe('onTabDiscarded', () => {

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -355,6 +355,14 @@ export const cookieCleanup: ActionCreator<ThunkAction<
 ) => async (dispatch, getState) => {
   const cleanupDoneObject = await cleanCookiesOperation(getState(), options);
   if (!cleanupDoneObject) return;
+
+  // Consume-and-clear: a startup (greyCleanup) run has now processed every
+  // recorded domain, so drop the registry. It repopulates as the user browses.
+  // Reached only after cleanCookiesOperation returned successfully.
+  if (options.greyCleanup) {
+    dispatch(clearDomainsToCleanUI());
+  }
+
   const { setOfDeletedDomainCookies, cachedResults } = cleanupDoneObject;
   const {
     browsingDataCleanup,

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -27,8 +27,10 @@ import {
 } from '../services/Libs';
 import {
   ADD_ACTIVITY_LOG,
+  ADD_DOMAIN_TO_CLEAN,
   ADD_EXPRESSION,
   CLEAR_ACTIVITY_LOG,
+  CLEAR_DOMAINS_TO_CLEAN,
   CLEAR_EXPRESSIONS,
   COOKIE_CLEANUP,
   INCREMENT_COOKIE_DELETED_COUNTER,
@@ -331,6 +333,15 @@ export const cookieCleanupUI = (
 ): COOKIE_CLEANUP => ({
   payload,
   type: ReduxConstants.COOKIE_CLEANUP,
+});
+
+export const addDomainToCleanUI = (payload: string): ADD_DOMAIN_TO_CLEAN => ({
+  payload,
+  type: ReduxConstants.ADD_DOMAIN_TO_CLEAN,
+});
+
+export const clearDomainsToCleanUI = (): CLEAR_DOMAINS_TO_CLEAN => ({
+  type: ReduxConstants.CLEAR_DOMAINS_TO_CLEAN,
 });
 
 // Cookie Cleanup operation that is to be called from the React UI

--- a/src/redux/Reducers.ts
+++ b/src/redux/Reducers.ts
@@ -239,11 +239,33 @@ export const cache = (
   }
 };
 
+export const domainsToClean = (
+  state: ReadonlyArray<string> = [],
+  action: ReduxAction,
+): ReadonlyArray<string> => {
+  switch (action.type) {
+    case ReduxConstants.ADD_DOMAIN_TO_CLEAN: {
+      if (action.payload.trim() === '' || state.includes(action.payload)) {
+        return state;
+      }
+      return [...state, action.payload];
+    }
+
+    case ReduxConstants.RESET_ALL:
+    case ReduxConstants.CLEAR_DOMAINS_TO_CLEAN:
+      return [];
+
+    default:
+      return state;
+  }
+};
+
 export default combineReducers<State, ReduxAction>({
   activityLog,
   cache,
   cookieDeletedCounterSession,
   cookieDeletedCounterTotal,
+  domainsToClean,
   lists,
   settings,
 });

--- a/src/redux/State.ts
+++ b/src/redux/State.ts
@@ -141,4 +141,5 @@ export const initialState: State = {
   },
   activityLog: [],
   cache: {},
+  domainsToClean: [],
 };

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -25,6 +25,7 @@ import {
   isFirefoxNotAndroid,
   prepareCleanupDomains,
   prepareCookieDomain,
+  PRIVATE_STORE_IDS,
   returnMatchedExpressionObject,
   returnOptionalCookieAPIAttributes,
   showNotification,
@@ -956,7 +957,7 @@ export const cleanCookiesOperation = async (
     siteDataCleaned: false,
   };
   // Scrub private cookieStores
-  const storesIdsToScrub = ['firefox-private', 'private', '1'];
+  const storesIdsToScrub = PRIVATE_STORE_IDS;
   const openTabDomains = await returnContainersOfOpenTabDomains(
     cleanupProperties.ignoreOpenTabs,
     getSetting(state, SettingID.CLEAN_DISCARDED) as boolean,

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -671,6 +671,49 @@ export const removeSiteData = async (
   }
 };
 
+/**
+ * Build synthetic CleanReasonObjects for the hostnames recorded in the
+ * site-data registry (state.domainsToClean). Each hostname is evaluated by the
+ * SAME isSafeToClean logic through a synthetic cookie, so whitelist/greylist
+ * and open-tab protection apply identically to registry domains. The returned
+ * objects must be passed ONLY to otherBrowsingDataCleanup — never to
+ * cleanCookies (there is no real cookie to remove).
+ *
+ * Site data is global, so the synthetic cookie uses the normalised 'default'
+ * store for list matching, and open-tab protection is widened to span every
+ * container (a hostname open in ANY store is kept).
+ */
+export const buildRegistrySiteDataObjects = (
+  state: State,
+  cleanupProperties: CleanupPropertiesInternal,
+): CleanReasonObject[] => {
+  const unionOpenDomains = new Set<string>();
+  Object.values(cleanupProperties.openTabDomains).forEach((domains) =>
+    domains.forEach((d) => unionOpenDomains.add(d)),
+  );
+  const registryProps: CleanupPropertiesInternal = {
+    ...cleanupProperties,
+    openTabDomains: { default: Array.from(unionOpenDomains) },
+  };
+  return (state.domainsToClean || [])
+    .filter((hostname) => hostname.trim() !== '')
+    .map((hostname) => {
+      const syntheticCookie: CookiePropertiesCleanup = {
+        domain: hostname,
+        hostname,
+        mainDomain: extractMainDomain(hostname),
+        name: 'CADSiteDataRegistry',
+        path: '/',
+        preparedCookieDomain: `https://${hostname}`,
+        secure: true,
+        session: false,
+        storeId: 'default',
+        value: '',
+      } as CookiePropertiesCleanup;
+      return isSafeToClean(state, syntheticCookie, registryProps);
+    });
+};
+
 /** This will use the browsingData's hostname/origin attribute to delete any extra browsing data */
 export const otherBrowsingDataCleanup = async (
   state: State,
@@ -1102,6 +1145,31 @@ export const cleanCookiesOperation = async (
         deletedSiteDataArrays[sd] = (deletedSiteDataArrays[sd] || []).concat(
           (storeResults[sd] as string[]).map((domain) => trimDot(domain)),
         );
+      }
+    }
+  }
+
+  // Startup safety-net: clean non-cookie site data for domains recorded in the
+  // registry (first-party sites visited during the previous session that may
+  // have left no cookie). Registry entries are global, so this runs once,
+  // outside the per-store loop. Only on startup (greyCleanup).
+  if (cleanupProperties.greyCleanup && (state.domainsToClean || []).length > 0) {
+    const registryObjects = buildRegistrySiteDataObjects(
+      state,
+      newCleanupProperties,
+    );
+    const registryResults = await otherBrowsingDataCleanup(
+      state,
+      registryObjects,
+    );
+    if (registryResults) {
+      for (const sd of SITEDATATYPES) {
+        if ((registryResults[sd] || []).length > 0) {
+          cachedResults.siteDataCleaned = true;
+          deletedSiteDataArrays[sd] = (deletedSiteDataArrays[sd] || []).concat(
+            (registryResults[sd] as string[]).map((domain) => trimDot(domain)),
+          );
+        }
       }
     }
   }

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -17,6 +17,7 @@ import shortid from 'shortid';
 
 /* --- CONSTANTS --- */
 export const CADCOOKIENAME = 'CookieAutoDeleteBrowsingDataCleanup';
+export const PRIVATE_STORE_IDS = ['firefox-private', 'private', '1'];
 export const SITEDATATYPES = [
   SiteDataType.CACHE,
   SiteDataType.INDEXEDDB,

--- a/src/services/TabEvents.ts
+++ b/src/services/TabEvents.ts
@@ -30,6 +30,7 @@ import {
   isFirstPartyIsolate,
   returnOptionalCookieAPIAttributes,
 } from './Libs';
+import { addDomainToCleanUI } from '../redux/Actions';
 import StoreUser from './StoreUser';
 
 export default class TabEvents extends StoreUser {
@@ -284,8 +285,7 @@ export default class TabEvents extends StoreUser {
       return c.name === CADCOOKIENAME;
     });
 
-    if (
-      internalCookies.length === 0 &&
+    const siteDataCleanupEnabled =
       (getSetting(StoreUser.store.getState(), SettingID.CLEANUP_CACHE) ||
         getSetting(StoreUser.store.getState(), SettingID.CLEANUP_INDEXEDDB) ||
         getSetting(
@@ -296,7 +296,29 @@ export default class TabEvents extends StoreUser {
         getSetting(
           StoreUser.store.getState(),
           SettingID.CLEANUP_SERVICEWORKERS,
-        )) &&
+        )) as boolean;
+
+    // Durable startup safety-net: record every first-party hostname visited
+    // while a site-data cleanup is enabled, so its non-cookie site data can be
+    // cleaned on the next startup even if it leaves no cookie (real or marker).
+    // Site data is global, so a flat hostname list (no storeId) is sufficient;
+    // private stores are excluded because their data does not persist.
+    const privateStores = ['firefox-private', 'private', '1'];
+    if (
+      siteDataCleanupEnabled &&
+      isAWebpage(tab.url) &&
+      !tab.url.startsWith('file:') &&
+      !privateStores.includes(tab.cookieStoreId || '')
+    ) {
+      const registryHostname = getHostname(tab.url);
+      if (registryHostname.trim() !== '') {
+        StoreUser.store.dispatch(addDomainToCleanUI(registryHostname));
+      }
+    }
+
+    if (
+      internalCookies.length === 0 &&
+      siteDataCleanupEnabled &&
       isAWebpage(tab.url) &&
       !tab.url.startsWith('file:')
     ) {

--- a/src/services/TabEvents.ts
+++ b/src/services/TabEvents.ts
@@ -303,9 +303,14 @@ export default class TabEvents extends StoreUser {
     // cleaned on the next startup even if it leaves no cookie (real or marker).
     // Site data is global, so a flat hostname list (no storeId) is sufficient;
     // private stores are excluded because their data does not persist.
+    // Only record when a future startup run will actually consume and clear
+    // the registry (ACTIVE_MODE + ENABLE_GREYLIST), otherwise the list would
+    // grow unbounded with no consumer.
     const privateStores = ['firefox-private', 'private', '1'];
     if (
       siteDataCleanupEnabled &&
+      getSetting(StoreUser.store.getState(), SettingID.ACTIVE_MODE) &&
+      getSetting(StoreUser.store.getState(), SettingID.ENABLE_GREYLIST) &&
       isAWebpage(tab.url) &&
       !tab.url.startsWith('file:') &&
       !privateStores.includes(tab.cookieStoreId || '')

--- a/src/services/TabEvents.ts
+++ b/src/services/TabEvents.ts
@@ -28,6 +28,7 @@ import {
   getSetting,
   isAWebpage,
   isFirstPartyIsolate,
+  PRIVATE_STORE_IDS,
   returnOptionalCookieAPIAttributes,
 } from './Libs';
 import { addDomainToCleanUI } from '../redux/Actions';
@@ -285,38 +286,42 @@ export default class TabEvents extends StoreUser {
       return c.name === CADCOOKIENAME;
     });
 
-    const siteDataCleanupEnabled =
-      (getSetting(StoreUser.store.getState(), SettingID.CLEANUP_CACHE) ||
-        getSetting(StoreUser.store.getState(), SettingID.CLEANUP_INDEXEDDB) ||
-        getSetting(
-          StoreUser.store.getState(),
-          SettingID.CLEANUP_LOCALSTORAGE,
-        ) ||
-        getSetting(StoreUser.store.getState(), SettingID.CLEANUP_PLUGINDATA) ||
-        getSetting(
-          StoreUser.store.getState(),
-          SettingID.CLEANUP_SERVICEWORKERS,
-        )) as boolean;
+    const siteDataCleanupEnabled = (getSetting(
+      StoreUser.store.getState(),
+      SettingID.CLEANUP_CACHE,
+    ) ||
+      getSetting(StoreUser.store.getState(), SettingID.CLEANUP_INDEXEDDB) ||
+      getSetting(StoreUser.store.getState(), SettingID.CLEANUP_LOCALSTORAGE) ||
+      getSetting(StoreUser.store.getState(), SettingID.CLEANUP_PLUGINDATA) ||
+      getSetting(
+        StoreUser.store.getState(),
+        SettingID.CLEANUP_SERVICEWORKERS,
+      )) as boolean;
 
     // Durable startup safety-net: record every first-party hostname visited
     // while a site-data cleanup is enabled, so its non-cookie site data can be
     // cleaned on the next startup even if it leaves no cookie (real or marker).
     // Site data is global, so a flat hostname list (no storeId) is sufficient;
-    // private stores are excluded because their data does not persist.
+    // private stores are excluded because their data does not persist. Chrome
+    // has no tab.cookieStoreId, so tab.incognito is used to detect its private
+    // browsing tabs.
     // Only record when a future startup run will actually consume and clear
     // the registry (ACTIVE_MODE + ENABLE_GREYLIST), otherwise the list would
     // grow unbounded with no consumer.
-    const privateStores = ['firefox-private', 'private', '1'];
+    const effectiveStoreId = tab.cookieStoreId || (tab.incognito ? '1' : '0');
     if (
       siteDataCleanupEnabled &&
       getSetting(StoreUser.store.getState(), SettingID.ACTIVE_MODE) &&
       getSetting(StoreUser.store.getState(), SettingID.ENABLE_GREYLIST) &&
       isAWebpage(tab.url) &&
       !tab.url.startsWith('file:') &&
-      !privateStores.includes(tab.cookieStoreId || '')
+      !PRIVATE_STORE_IDS.includes(effectiveStoreId)
     ) {
       const registryHostname = getHostname(tab.url);
-      if (registryHostname.trim() !== '') {
+      if (
+        registryHostname.trim() !== '' &&
+        !StoreUser.store.getState().domainsToClean.includes(registryHostname)
+      ) {
         StoreUser.store.dispatch(addDomainToCleanUI(registryHostname));
       }
     }

--- a/src/typings/Global.d.ts
+++ b/src/typings/Global.d.ts
@@ -52,6 +52,7 @@ type State = Readonly<{
   settings: MapToSettingObject;
   activityLog: ReadonlyArray<ActivityLog>;
   cache: CacheMap;
+  domainsToClean: ReadonlyArray<string>;
 }>;
 
 type Expression = Readonly<{

--- a/src/typings/ReduxConstants.ts
+++ b/src/typings/ReduxConstants.ts
@@ -28,6 +28,8 @@ export const enum ReduxConstants {
   ADD_ACTIVITY_LOG = 'ADD_ACTIVITY_LOG',
   CLEAR_ACTIVITY_LOG = 'CLEAR_ACTIVITY_LOG',
   REMOVE_ACTIVITY_LOG = 'REMOVE_ACTIVITY_LOG',
+  ADD_DOMAIN_TO_CLEAN = 'ADD_DOMAIN_TO_CLEAN',
+  CLEAR_DOMAINS_TO_CLEAN = 'CLEAR_DOMAINS_TO_CLEAN',
   RESET_ALL = 'RESET_ALL',
 }
 
@@ -47,6 +49,8 @@ export type ReduxAction =
   | ADD_ACTIVITY_LOG
   | CLEAR_ACTIVITY_LOG
   | REMOVE_ACTIVITY_LOG
+  | ADD_DOMAIN_TO_CLEAN
+  | CLEAR_DOMAINS_TO_CLEAN
   | RESET_ALL;
 
 export type ADD_EXPRESSION = Readonly<{
@@ -107,4 +111,11 @@ export type REMOVE_ACTIVITY_LOG = Readonly<{
 }>;
 export type CLEAR_ACTIVITY_LOG = Readonly<{
   type: ReduxConstants.CLEAR_ACTIVITY_LOG;
+}>;
+export type ADD_DOMAIN_TO_CLEAN = Readonly<{
+  type: ReduxConstants.ADD_DOMAIN_TO_CLEAN;
+  payload: string;
+}>;
+export type CLEAR_DOMAINS_TO_CLEAN = Readonly<{
+  type: ReduxConstants.CLEAR_DOMAINS_TO_CLEAN;
 }>;


### PR DESCRIPTION
## Problem

On browser startup, CAD only cleaned site data (localStorage, IndexedDB, cache, service workers, plugin data) for domains that left a **cookie** behind — the whole startup pipeline derives its clean-list from cookies. A site that leaves only non-cookie data but no cookie was never cleaned. The existing marker-cookie workaround is fragile (depends on visiting the tab while CAD runs, and on the marker cookie surviving to the next startup).

## Solution — a conservative, cross-browser domain registry

A new persisted `domainsToClean` slice records every first-party hostname you visit while site-data cleanup is enabled. On startup (`greyCleanup`), each recorded hostname is turned into a synthetic `CleanReasonObject` and run through the **existing** `isSafeToClean` → `otherBrowsingDataCleanup` pipeline, so whitelist / greylist / open-tab / CHIPS protections apply identically — then the registry is consumed-and-cleared. It **complements** (does not replace) the marker-cookie mechanism.

Design decisions (from brainstorming): conservative registry (not a Chrome-only `excludeOrigins` global wipe), complement not replace, record every first-party domain, consume-and-clear at startup. Same behaviour on Chrome and Firefox via hostname-based `browsingData.remove`.

## Changes

- `domainsToClean` redux slice (state, constants, reducer, action creators) — auto-persisted with the rest of `State`.
- Record visited first-party hostnames in `TabEvents.getAllCookieActions` (gated on `ACTIVE_MODE && ENABLE_GREYLIST` so the list can't grow without a consumer; private stores and Chrome incognito excluded).
- Consume the registry at startup in `cleanCookiesOperation` via `buildRegistrySiteDataObjects` (synthetic cookies, keep-if-open-in-any-container).
- Clear the registry after a successful startup run in the `cookieCleanup` thunk.

## Testing

- New unit tests across reducer, `TabEvents` recording (incl. disabled/inactive/incognito exclusions), `cleanCookiesOperation` registry consumption (incl. whitelist protection and non-startup no-op), and the thunk clear.
- Full suite: **550/550 passing**, `npm run compile` clean.

## Known trade-offs (deferred)

- Consume-and-clear removes recorded domains after the run regardless of whether each `browsingData.remove` succeeded (consistent with the existing cookie path).
- A hostname recorded during the brief startup-cleanup window is cleared without being processed that startup (re-recorded on next visit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)