### PR TITLE
chore: add agent guidance docs and 1.2.0 release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,144 @@
+# AGENTS.md
+
+Guidance for any AI agent working in this repository.
+
+## What this is
+
+Cookie AutoDelete V3 — a **Manifest V3** browser extension (TypeScript + React +
+Redux) that auto-deletes unwanted cookies and other site data. It's a MV3 fork of
+the original Cookie AutoDelete. Ships one codebase to both **Chromium** (Chrome /
+Edge / Brave / Vivaldi) and **Firefox**; the two differ only by a manifest patch
+at build time.
+
+## Working agreements
+
+- **Never push to `main`.** Work on a branch and open a PR. `main` is protected and
+  a push to it auto-publishes a release (see Release process).
+- **Every PR updates the release notes.** Add/extend an entry in
+  `src/ui/settings/ReleaseNotes.json` under the version this PR ships in. That file
+  feeds the "What's New" Welcome tab users see after an update.
+- **Code is self-explaining.** Prefer clear names over comments. Add a comment only
+  when the *why* is non-obvious (e.g. an MV3 service-worker quirk, a
+  cross-browser workaround) — the existing comments in `src/background/` are the
+  bar to match, not to exceed.
+- Run `npm run test-all` (tests + lint) before opening a PR. Lint is zero-warnings.
+
+## Commands
+
+```bash
+npm run compile        # webpack production build -> extension/bundles/
+npm run dev            # webpack --watch (rebuild on change)
+npm run build          # compile + package BOTH Chrome & Firefox into builds/
+npm run build:chrome   # package Chromium only (optional version bump, see below)
+npm run build:firefox  # package Firefox only
+npm run lint           # eslint, --max-warnings 0
+npm test               # jest
+npm run test-all       # test + lint (run before every PR)
+npm run test:coverage  # jest with coverage
+```
+
+Run a single test file / name:
+
+```bash
+npx jest __tests__/tools/resolveBuildVersion.test.js
+npx jest -t "partitioned"
+```
+
+Version bump (writes both `package.json` **and** `extension/manifest.json`):
+
+```bash
+npm run build:chrome patch   # or minor | major; no arg = no bump
+node ./tools/bumpVersion.js minor
+```
+
+Requires Node ≥ 22.
+
+## Architecture
+
+### Two build targets, one source
+
+`extension/manifest.json` is authored as the Chromium MV3 manifest. At package time
+`tools/buildFilesDev.js` clones it in memory and patches per target
+(`chromePatchManifest` / `firefoxPatchManifest`): Firefox gets the
+`contextualIdentities` permission + `browser_specific_settings` and its
+`service_worker` entry is rewritten to `background.scripts`; Chromium gets those
+stripped. The on-disk manifest is restored after each zip. **Don't hand-edit the
+manifest per browser — change the patch functions.**
+
+`webext-browser` types + `webextension-polyfill` give one `browser.*` API across
+both. MV3/Chrome-only surfaces absent from the Firefox type defs (e.g.
+`runtime.onSuspend`) are reached through explicit casts — see the bottom of
+`src/background/index.ts`.
+
+### Background service worker — `src/background/`
+
+MV3 terminates the SW aggressively, which drives the design here:
+
+- **`index.ts`** registers every event listener **synchronously at module top
+  level** so Chrome wakes the SW on the event, then `await ready()` before touching
+  the store. Registering listeners late (inside async init) means a cold wake
+  misses the first message — that's why the redux-webext connect/message protocol
+  is re-implemented inline here instead of via `createBackgroundStore`.
+- **`lifecycle.ts`** owns one-time init (`ready()` — idempotent, retryable),
+  `getStore()`, and the **save debouncer**. State persists to
+  `storage.local` (full state) and `storage.session` (the `cache` slice); a
+  synchronous `flushSave()` on `runtime.onSuspend` guards against loss on
+  termination.
+- **`whatsNew.ts`** opens the Welcome tab on version update (gated by a setting).
+
+### State — `src/redux/`
+
+Redux + redux-thunk. `State.ts` / `Reducers.ts` / `Actions.ts`, with the shared
+`State` / `Expression` / `Setting` shapes and the `SettingID`, `SiteDataType`,
+`ListType` **const enums** declared globally in `src/typings/Global.d.ts` (no
+import needed). The UI talks to the background store over **redux-webext**: the
+popup/settings dispatch actions that the background applies to the single source
+of truth, then pushes state back over the port.
+
+### Cleanup engine — `src/services/`
+
+`CleanupService.ts` is the core: decides what to delete on tab-close / domain-change
+/ manual / startup, honouring the **whitelist / greylist** expression lists and
+per-expression `cleanSiteData` flags. Cookies are removed via `chrome.cookies`
+(partition-aware — supports CHIPS `partitionKey`); non-cookie site data goes through
+`chrome.browsingData.remove*`, which is **host-scoped only, not partition-aware**.
+That asymmetry is why cross-site partitioned entries get their cookies cleaned but
+their cache/storage left alone — see `isCrossSitePartitioned` and the full rationale
+in `docs/chrome-vs-extensions-api.md`. Other services: `TabEvents`, `CookieEvents`,
+`AlarmScheduler`/`AlarmEvents`, `ContextMenuEvents`, `BrowserActionService` (icon),
+`BrowserDetect`, `SettingService`, and `Libs.ts` (shared helpers: domain parsing,
+`getSetting`, `cadLog`, CHIPS detection).
+
+### UI — `src/ui/`
+
+Two independent React roots built as separate webpack entries: `popup/`
+(per-site quick actions) and `settings/` (full options, expression tables, activity
+log, Welcome/What's-New). `common_components/` is shared. Each entry ships as **one
+self-contained bundle** (`splitChunks: false`) — MV3 SWs and `chrome-extension://`
+pages can't reliably load webpack's async split chunks.
+
+## Release process
+
+`package.json` version is the **source of truth** (kept in sync with
+`extension/manifest.json` by `tools/bumpVersion.js`). Pushing to `main`
+(`.github/workflows/release-on-main.yml`) resolves that version and, **only if a
+`v<version>` release doesn't already exist**, runs test → lint → build and publishes
+a GitHub Release with the Chrome `.zip` + Firefox `.xpi`. So a release is cut by
+merging a version bump to `main` — never by pushing directly.
+
+## Tests
+
+Jest + ts-jest. Tests live under `__tests__/` (currently the build tooling and
+release workflows); setup in `__tests__/setup.js`, `testEnvironment: node`.
+
+## Agent skills
+
+### Issue tracker
+
+Issues and PRDs are tracked in this repo's GitHub Issues, using the `gh` CLI. See
+`docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+Single-context layout — one `CONTEXT.md` and `docs/adr/` at the repo root. See
+`docs/agents/domain.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,5 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+@AGENTS.md

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill (reached via `/grill-with-docs` and `/improve-codebase-architecture`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -5,7 +5,7 @@ Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all op
 ## Conventions
 
 - **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
-- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **Read an issue**: `gh issue view <number> --comments` for a human-readable view. To filter with `jq`, request JSON instead — `--comments` alone prints plain text: `gh issue view <number> --json title,body,labels,comments --jq '...'`.
 - **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
 - **Comment on an issue**: `gh issue comment <number> --body "..."`
 - **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
@@ -20,7 +20,7 @@ Infer the repo from `git remote -v` — `gh` does this automatically when run in
 When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
 
 - **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
-- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **List external PRs for triage**: `gh pr list --json` doesn't expose the author association, so use the REST API: `gh api repos/<owner>/<repo>/pulls --paginate --jq '[.[] | select(.state=="open") | {number, title, user: .user.login, author_association}]'`, then keep only `author_association` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
 - **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
 
 GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -1,6 +1,13 @@
 {
   "releases": [
     {
+      "version": "1.2.0",
+      "notes": [
+        "New 'File System' site-data cleanup (Chromium browsers) — clears File System API data that sites like mega.nz leave behind in your profile. Plugin Data cleanup is now hidden on Chromium, since it's deprecated there and no longer has any effect.",
+        "Non-cookie site data (cache, IndexedDB, local storage, service workers, File System) from the sites you visit is now also cleaned on browser startup — covering sites that leave no cookie behind and were previously missed by tab-close cleanup."
+      ]
+    },
+    {
       "version": "1.1.0",
       "notes": [
         "Whitelisted sites now have a 'First-party cookies only' cookie option (Chromium browsers) — delete third-party partitioned (CHIPS) cookies stored under a site even when their own domain is whitelisted."


### PR DESCRIPTION
## Summary

Bundles the current uncommitted working-tree changes into one PR:

- **`AGENTS.md` / `CLAUDE.md`** — working agreements and guidance for AI agents in this repo (architecture map, commands, release process).
- **`docs/agents/domain.md` / `docs/agents/issue-tracker.md`** — agent skill docs referenced from AGENTS.md.
- **`ReleaseNotes.json`** — adds the `1.2.0` entry documenting the already-merged features:
  - File System site-data cleanup on Chromium + hiding deprecated Plugin Data (#70)
  - Startup cleanup of non-cookie site data via the visited-domain registry (#81)

## Note on versioning

`package.json` / `extension/manifest.json` are still at **1.1.0**. This PR only records the `1.2.0` notes — it does **not** bump the version, so merging it will not cut a release. When you're ready to ship 1.2.0, run a version bump (`npm run build:chrome minor`) so the "What's New" tab surfaces these notes to users.

🤖 Generated with [Claude Code](https://claude.com/claude-code)