### PR TITLE
feat(#80): merge marker-cookie into the site-data registry

### DIFF
--- a/__tests__/redux/Actions.spec.ts
+++ b/__tests__/redux/Actions.spec.ts
@@ -80,16 +80,53 @@ describe('cookieCleanup', () => {
     expect(store.getState().domainsToClean).toEqual([]);
   });
 
-  it('does NOT clear domainsToClean on a non-startup (greyCleanup=false) cleanup', async () => {
+  it('keeps registry domains that were not cleaned on a non-startup (greyCleanup=false) cleanup', async () => {
     const store: Store<State, ReduxAction> = createStore({
       ...initialState,
       domainsToClean: ['a.com'],
+    });
+
+    // browsingDataCleanup is empty (nothing cleaned), so nothing is dropped.
+    await store.dispatch<any>(
+      Actions.cookieCleanup({ greyCleanup: false, ignoreOpenTabs: false }),
+    );
+
+    expect(store.getState().domainsToClean).toEqual(['a.com']);
+  });
+
+  it('on a non-startup cleanup, drops only the registry domains that were actually cleaned', async () => {
+    when(spyCleanupService.cleanCookiesOperation)
+      .calledWith(expect.any(Object), expect.any(Object))
+      .mockResolvedValue({
+        setOfDeletedDomainCookies: [],
+        cachedResults: {
+          dateTime: 'now',
+          recentlyCleaned: 0,
+          storeIds: {},
+          browsingDataCleanup: {
+            [SiteDataType.LOCALSTORAGE]: ['a.com'],
+          },
+          siteDataCleaned: true,
+        },
+      } as never);
+    const store: Store<State, ReduxAction> = createStore({
+      ...initialState,
+      settings: {
+        ...initialState.settings,
+        [SettingID.NOTIFY_AUTO]: {
+          name: SettingID.NOTIFY_AUTO,
+          value: false,
+        },
+      },
+      domainsToClean: ['a.com', 'protected.com'],
     });
 
     await store.dispatch<any>(
       Actions.cookieCleanup({ greyCleanup: false, ignoreOpenTabs: false }),
     );
 
-    expect(store.getState().domainsToClean).toEqual(['a.com']);
+    // 'a.com' was cleaned so it is dropped; 'protected.com' (e.g. open tab or
+    // whitelisted, hence not cleaned) is kept for a later run.
+    expect(store.getState().domainsToClean).toEqual(['protected.com']);
   });
 });

--- a/__tests__/redux/Reducer.spec.ts
+++ b/__tests__/redux/Reducer.spec.ts
@@ -547,6 +547,23 @@ describe('Reducer', () => {
       expect(result).toEqual([]);
     });
 
+    it('should remove only the listed hostnames on REMOVE_DOMAINS_TO_CLEAN', () => {
+      const result = domainsToClean(['a.com', 'b.com', 'c.com'], {
+        payload: ['a.com', 'c.com'],
+        type: ReduxConstants.REMOVE_DOMAINS_TO_CLEAN,
+      });
+      expect(result).toEqual(['b.com']);
+    });
+
+    it('should be a no-op on REMOVE_DOMAINS_TO_CLEAN with an empty payload', () => {
+      const state = ['a.com', 'b.com'];
+      const result = domainsToClean(state, {
+        payload: [],
+        type: ReduxConstants.REMOVE_DOMAINS_TO_CLEAN,
+      });
+      expect(result).toBe(state);
+    });
+
     it('should clear on RESET_ALL', () => {
       const result = domainsToClean(['a.com'], {
         type: ReduxConstants.RESET_ALL,

--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -887,7 +887,7 @@ describe('CleanupService', () => {
       expect(cleanedHostnames).toContain('registry-only.com');
     });
 
-    it('does NOT consume the registry during a non-startup (greyCleanup=false) run', async () => {
+    it('also cleans site data for a registry hostname during a non-startup (greyCleanup=false) run', async () => {
       await cleanCookiesOperation(firefoxRegistryState, {
         greyCleanup: false,
         ignoreOpenTabs: false,
@@ -899,7 +899,7 @@ describe('CleanupService', () => {
           acc.concat((c[0] as { hostnames?: string[] }).hostnames || []),
         [] as string[],
       );
-      expect(cleanedHostnames).not.toContain('registry-only.com');
+      expect(cleanedHostnames).toContain('registry-only.com');
     });
 
     it('does NOT clean a registry hostname that is whitelisted', async () => {

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -173,7 +173,10 @@ describe('TabEvents', () => {
       expect(spyBrowserActions.checkIfProtected.mock.calls[0][2]).toBe(1);
     });
 
-    it('should create a cookie if clean cache was enabled and no CAD cookie was found', async () => {
+    // CAD no longer plants a marker cookie on cookieless sites; it records the
+    // hostname in the domainsToClean registry instead. One case per site-data
+    // type to confirm every trigger still records without setting a cookie.
+    it('should record the hostname and NOT set a marker cookie when clean cache is enabled and no cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -182,10 +185,11 @@ describe('TabEvents', () => {
         ...sampleTab,
         url: 'http://cookie.net',
       });
-      expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
+      expect(global.browser.cookies.set).not.toHaveBeenCalled();
+      expect(store.getState().domainsToClean).toContain('cookie.net');
     });
 
-    it('should create a cookie if clean indexedDB was enabled and no CAD cookie was found', async () => {
+    it('should record the hostname and NOT set a marker cookie when clean indexedDB is enabled and no cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -194,10 +198,11 @@ describe('TabEvents', () => {
         ...sampleTab,
         url: 'http://cookie.net',
       });
-      expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
+      expect(global.browser.cookies.set).not.toHaveBeenCalled();
+      expect(store.getState().domainsToClean).toContain('cookie.net');
     });
 
-    it('should create a cookie if clean localStorage was enabled and no CAD cookie was found', async () => {
+    it('should record the hostname and NOT set a marker cookie when clean localStorage is enabled and no cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -206,10 +211,11 @@ describe('TabEvents', () => {
         ...sampleTab,
         url: 'http://cookie.net',
       });
-      expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
+      expect(global.browser.cookies.set).not.toHaveBeenCalled();
+      expect(store.getState().domainsToClean).toContain('cookie.net');
     });
 
-    it('should create a cookie if clean plugin data was enabled and no CAD cookie was found', async () => {
+    it('should record the hostname and NOT set a marker cookie when clean plugin data is enabled and no cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -218,10 +224,11 @@ describe('TabEvents', () => {
         ...sampleTab,
         url: 'http://cookie.net',
       });
-      expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
+      expect(global.browser.cookies.set).not.toHaveBeenCalled();
+      expect(store.getState().domainsToClean).toContain('cookie.net');
     });
 
-    it('should create a cookie if clean service workers was enabled and no CAD cookie was found', async () => {
+    it('should record the hostname and NOT set a marker cookie when clean service workers is enabled and no cookie was found', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -230,7 +237,8 @@ describe('TabEvents', () => {
         ...sampleTab,
         url: 'http://cookie.net',
       });
-      expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
+      expect(global.browser.cookies.set).not.toHaveBeenCalled();
+      expect(store.getState().domainsToClean).toContain('cookie.net');
     });
 
     it('should filter out CAD browsingDataCleanup cookie from total cookie count', async () => {
@@ -255,27 +263,6 @@ describe('TabEvents', () => {
       expect(
         spyBrowserActions.showNumberOfCookiesInIcon,
       ).not.toHaveBeenCalled();
-    });
-
-    it('should create a cookie with firstPartyDomain if FPI is enabled', async () => {
-      when(global.browser.cookies.getAll)
-        .calledWith({ domain: 'cookie.net', storeId: 'firefox-default' })
-        .mockResolvedValue([] as never);
-      when(global.browser.cookies.getAll)
-        .calledWith({ domain: '' })
-        .mockResolvedValueOnce([] as never)
-        .mockRejectedValue(new Error('firstPartyDomain') as never);
-      TestStore.changeSetting(SettingID.CLEANUP_CACHE, true);
-      TestStore.addCache({ key: 'browserDetect', value: browserName.Firefox });
-
-      await TabEvents.getAllCookieActions({
-        ...sampleTab,
-        url: 'http://cookie.net',
-      });
-      expect(global.browser.cookies.set).toHaveBeenCalledTimes(1);
-      expect(global.browser.cookies.set.mock.calls[0][0]).toHaveProperty(
-        'firstPartyDomain',
-      );
     });
 
     it('should record the hostname in domainsToClean when a site-data cleanup is enabled', async () => {
@@ -324,7 +311,10 @@ describe('TabEvents', () => {
       expect(store.getState().domainsToClean).not.toContain('plain.net');
     });
 
-    it('should NOT record the hostname when ACTIVE_MODE is disabled, even if a site-data cleanup is enabled', async () => {
+    // The registry replaces the marker cookie, whose gate did not depend on
+    // ACTIVE_MODE/ENABLE_GREYLIST, so recording must not either — otherwise
+    // manual-mode users would lose cookieless site-data cleanup.
+    it('should record the hostname when ACTIVE_MODE is disabled, as long as a site-data cleanup is enabled', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'inactive.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -334,10 +324,10 @@ describe('TabEvents', () => {
         ...sampleTab,
         url: 'http://inactive.net',
       });
-      expect(store.getState().domainsToClean).not.toContain('inactive.net');
+      expect(store.getState().domainsToClean).toContain('inactive.net');
     });
 
-    it('should NOT record the hostname when ENABLE_GREYLIST is disabled, even if a site-data cleanup is enabled', async () => {
+    it('should record the hostname when ENABLE_GREYLIST is disabled, as long as a site-data cleanup is enabled', async () => {
       when(global.browser.cookies.getAll)
         .calledWith({ domain: 'nogreylist.net', storeId: 'firefox-default' })
         .mockResolvedValue([] as never);
@@ -347,7 +337,7 @@ describe('TabEvents', () => {
         ...sampleTab,
         url: 'http://nogreylist.net',
       });
-      expect(store.getState().domainsToClean).not.toContain('nogreylist.net');
+      expect(store.getState().domainsToClean).toContain('nogreylist.net');
     });
 
     it('should NOT record the hostname for a Chrome incognito tab (no cookieStoreId, incognito=true)', async () => {

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -37,6 +37,7 @@ import {
   ReduxAction,
   ReduxConstants,
   REMOVE_ACTIVITY_LOG,
+  REMOVE_DOMAINS_TO_CLEAN,
   REMOVE_EXPRESSION,
   REMOVE_LIST,
   RESET_ALL,
@@ -344,6 +345,13 @@ export const clearDomainsToCleanUI = (): CLEAR_DOMAINS_TO_CLEAN => ({
   type: ReduxConstants.CLEAR_DOMAINS_TO_CLEAN,
 });
 
+export const removeDomainsToCleanUI = (
+  payload: ReadonlyArray<string>,
+): REMOVE_DOMAINS_TO_CLEAN => ({
+  payload,
+  type: ReduxConstants.REMOVE_DOMAINS_TO_CLEAN,
+});
+
 // Cookie Cleanup operation that is to be called from the React UI
 export const cookieCleanup: ActionCreator<ThunkAction<
   void,
@@ -356,19 +364,35 @@ export const cookieCleanup: ActionCreator<ThunkAction<
   const cleanupDoneObject = await cleanCookiesOperation(getState(), options);
   if (!cleanupDoneObject) return;
 
-  // Consume-and-clear: a startup (greyCleanup) run has now processed every
-  // recorded domain, so drop the registry. It repopulates as the user browses.
-  // Reached only after cleanCookiesOperation returned successfully.
-  if (options.greyCleanup) {
-    dispatch(clearDomainsToCleanUI());
-  }
-
   const { setOfDeletedDomainCookies, cachedResults } = cleanupDoneObject;
   const {
     browsingDataCleanup,
     recentlyCleaned,
     siteDataCleaned,
   } = cachedResults as ActivityLog;
+
+  // Consume the site-data registry (state.domainsToClean) now that this run has
+  // evaluated it. Reached only after cleanCookiesOperation returned successfully.
+  // A startup (greyCleanup) run processes the whole registry, so drop all of it;
+  // it repopulates as the user browses. An active/manual run only cleaned the
+  // domains that were not open-tab or whitelist protected, so drop exactly those
+  // and keep the rest for a later run (they reset on the next startup anyway).
+  if (options.greyCleanup) {
+    dispatch(clearDomainsToCleanUI());
+  } else if ((getState().domainsToClean || []).length > 0) {
+    const cleanedSiteDataDomains = new Set<string>();
+    if (browsingDataCleanup) {
+      Object.values(browsingDataCleanup).forEach((domains) => {
+        (domains || []).forEach((d) => cleanedSiteDataDomains.add(d));
+      });
+    }
+    const processed = getState().domainsToClean.filter((hostname) =>
+      cleanedSiteDataDomains.has(hostname),
+    );
+    if (processed.length > 0) {
+      dispatch(removeDomainsToCleanUI(processed));
+    }
+  }
 
   // Increment the count
   if (recentlyCleaned !== 0 && getSetting(getState(), SettingID.STAT_LOGGING)) {

--- a/src/redux/Reducers.ts
+++ b/src/redux/Reducers.ts
@@ -251,6 +251,12 @@ export const domainsToClean = (
       return [...state, action.payload];
     }
 
+    case ReduxConstants.REMOVE_DOMAINS_TO_CLEAN: {
+      if (action.payload.length === 0) return state;
+      const toRemove = new Set(action.payload);
+      return state.filter((hostname) => !toRemove.has(hostname));
+    }
+
     case ReduxConstants.RESET_ALL:
     case ReduxConstants.CLEAR_DOMAINS_TO_CLEAN:
       return [];

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -1160,11 +1160,14 @@ export const cleanCookiesOperation = async (
     }
   }
 
-  // Startup safety-net: clean non-cookie site data for domains recorded in the
-  // registry (first-party sites visited during the previous session that may
-  // have left no cookie). Registry entries are global, so this runs once,
-  // outside the per-store loop. Only on startup (greyCleanup).
-  if (cleanupProperties.greyCleanup && (state.domainsToClean || []).length > 0) {
+  // Safety-net: clean non-cookie site data for domains recorded in the registry
+  // (first-party sites visited that may have left no cookie). This is the single
+  // source of truth for cookieless sites, replacing the old marker cookie, so it
+  // runs on every cleanup — tab-close/active, manual and startup — not just on
+  // startup. Registry entries are global, so this runs once, outside the
+  // per-store loop. isSafeToClean still applies whitelist/greylist and open-tab
+  // protection, so only unprotected domains are cleaned.
+  if ((state.domainsToClean || []).length > 0) {
     const registryObjects = buildRegistrySiteDataObjects(
       state,
       newCleanupProperties,

--- a/src/services/TabEvents.ts
+++ b/src/services/TabEvents.ts
@@ -12,7 +12,6 @@
  * SOFTWARE.
  */
 
-import shortid from 'shortid';
 import AlarmEvents from './AlarmEvents';
 import {
   checkIfProtected,
@@ -27,9 +26,7 @@ import {
   getHostname,
   getSetting,
   isAWebpage,
-  isFirstPartyIsolate,
   PRIVATE_STORE_IDS,
-  returnOptionalCookieAPIAttributes,
 } from './Libs';
 import { addDomainToCleanUI } from '../redux/Actions';
 import StoreUser from './StoreUser';
@@ -299,21 +296,9 @@ export default class TabEvents extends StoreUser {
         SettingID.CLEANUP_SERVICEWORKERS,
       )) as boolean;
 
-    // Durable startup safety-net: record every first-party hostname visited
-    // while a site-data cleanup is enabled, so its non-cookie site data can be
-    // cleaned on the next startup even if it leaves no cookie (real or marker).
-    // Site data is global, so a flat hostname list (no storeId) is sufficient;
-    // private stores are excluded because their data does not persist. Chrome
-    // has no tab.cookieStoreId, so tab.incognito is used to detect its private
-    // browsing tabs.
-    // Only record when a future startup run will actually consume and clear
-    // the registry (ACTIVE_MODE + ENABLE_GREYLIST), otherwise the list would
-    // grow unbounded with no consumer.
     const effectiveStoreId = tab.cookieStoreId || (tab.incognito ? '1' : '0');
     if (
       siteDataCleanupEnabled &&
-      getSetting(StoreUser.store.getState(), SettingID.ACTIVE_MODE) &&
-      getSetting(StoreUser.store.getState(), SettingID.ENABLE_GREYLIST) &&
       isAWebpage(tab.url) &&
       !tab.url.startsWith('file:') &&
       !PRIVATE_STORE_IDS.includes(effectiveStoreId)
@@ -327,36 +312,6 @@ export default class TabEvents extends StoreUser {
       }
     }
 
-    if (
-      internalCookies.length === 0 &&
-      siteDataCleanupEnabled &&
-      isAWebpage(tab.url) &&
-      !tab.url.startsWith('file:')
-    ) {
-      const cookiesAttributes = returnOptionalCookieAPIAttributes(
-        StoreUser.store.getState(),
-        {
-          expirationDate: Math.floor(Date.now() / 1000 + 31557600),
-          firstPartyDomain: (await isFirstPartyIsolate())
-            ? extractMainDomain(getHostname(tab.url))
-            : '',
-          name: CADCOOKIENAME,
-          path: `/${shortid.generate()}`,
-          storeId: tab.cookieStoreId,
-          url: tab.url,
-          value: CADCOOKIENAME,
-        },
-      );
-      await browser.cookies.set({ ...cookiesAttributes, url: tab.url });
-      cadLog(
-        {
-          msg: 'TabEvents.getAllCookieActions:  A temporary cookie has been set for future BrowsingData cleaning as the site did not set any cookies yet.',
-          x: { partialTabInfo, cadLSCookie: cookiesAttributes },
-        },
-        debug,
-      );
-    }
-    // Filter out cookie(s) that were set by this extension.
     const cookieLength = cookies.length - internalCookies.length;
     if (cookies.length !== cookieLength) {
       cadLog(

--- a/src/typings/ReduxConstants.ts
+++ b/src/typings/ReduxConstants.ts
@@ -30,6 +30,7 @@ export const enum ReduxConstants {
   REMOVE_ACTIVITY_LOG = 'REMOVE_ACTIVITY_LOG',
   ADD_DOMAIN_TO_CLEAN = 'ADD_DOMAIN_TO_CLEAN',
   CLEAR_DOMAINS_TO_CLEAN = 'CLEAR_DOMAINS_TO_CLEAN',
+  REMOVE_DOMAINS_TO_CLEAN = 'REMOVE_DOMAINS_TO_CLEAN',
   RESET_ALL = 'RESET_ALL',
 }
 
@@ -51,6 +52,7 @@ export type ReduxAction =
   | REMOVE_ACTIVITY_LOG
   | ADD_DOMAIN_TO_CLEAN
   | CLEAR_DOMAINS_TO_CLEAN
+  | REMOVE_DOMAINS_TO_CLEAN
   | RESET_ALL;
 
 export type ADD_EXPRESSION = Readonly<{
@@ -118,4 +120,8 @@ export type ADD_DOMAIN_TO_CLEAN = Readonly<{
 }>;
 export type CLEAR_DOMAINS_TO_CLEAN = Readonly<{
   type: ReduxConstants.CLEAR_DOMAINS_TO_CLEAN;
+}>;
+export type REMOVE_DOMAINS_TO_CLEAN = Readonly<{
+  type: ReduxConstants.REMOVE_DOMAINS_TO_CLEAN;
+  payload: ReadonlyArray<string>;
 }>;


### PR DESCRIPTION
Closes #80.

## What & why

CAD used **two parallel mechanisms** to clean non-cookie site data for sites that leave no cookie:

1. **Marker cookie** — a temporary `CADCOOKIENAME` cookie planted on cookieless sites so the cookie-driven engine would "see" them (worked in active-mode / tab-close).
2. **Registry** (`state.domainsToClean`) — a durable list of visited cookieless hostnames, consumed only on **startup**.

The marker cookie was kept separate initially to de-risk the registry. Now that the registry is proven, this PR retires the marker cookie and makes the registry the **single source of truth** — no more planting a fake cookie on the user's sites, no `firstPartyDomain`/CHIPS edge cases.

## Changes

- **`TabEvents`**: stop setting the marker cookie. Broaden the registry gate to record cookieless first-party sites whenever any site-data cleanup is enabled (dropped the `ACTIVE_MODE`/`ENABLE_GREYLIST` requirement) so it matches the marker cookie's old coverage — **manual-mode users keep the same behavior, no regression**. Leftover marker cookies from older builds are still excluded from icon counts and get cleaned like any other cookie.
- **`CleanupService`**: consume the registry on **every** cleanup run (tab-close, manual, startup), not just startup. Whitelist/greylist and open-tab protection still apply via `isSafeToClean`.
- **Consume-and-clear**: startup clears the whole registry (unchanged); a non-startup run drops **only** the domains it actually cleaned (new `REMOVE_DOMAINS_TO_CLEAN` action), keeping protected/whitelisted ones for a later run.

## Tests

Updated the 8 tests that encoded the old marker-cookie / gate behavior; added coverage for the new reducer action and the non-startup pruning. **559/559 pass, lint zero-warnings.**

## Notes

- **No release-notes entry / version bump** in this PR — `package.json` stays at `1.2.0`, so merging does not cut a release. Bundle this with a version bump (`node ./tools/bumpVersion.js patch` + a `ReleaseNotes.json` entry) when you want it shipped.
- User-facing behavior is unchanged (1:1 replacement); the only observable difference is that the extension no longer adds its own cookie to cookieless sites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)