### PR TITLE
fix: manual LocalStorage cleanup on Manifest V3 (v1.2.1)

### DIFF
--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -19,7 +19,6 @@ import {
   cleanCookiesOperation,
   cleanSiteData,
   clearCookiesForThisDomain,
-  clearLocalStorageForThisDomain,
   clearSiteDataForThisDomain,
   filterSiteData,
   isSafeToClean,
@@ -1125,41 +1124,6 @@ describe('CleanupService', () => {
         storeId: 'firefox-default',
         partitionKey: {},
       });
-    });
-  });
-
-  describe('clearLocalStorageForThisDomain()', () => {
-    it('should clear localstorage from active tab (via tabs.executeScript)', async () => {
-      when(global.browser.tabs.executeScript)
-        .calledWith(expect.any(Object))
-        .mockResolvedValue([{ local: 2, session: 0 }] as never);
-      expect(
-        await clearLocalStorageForThisDomain(initialState, sampleTab),
-      ).toBe(true);
-      expect(global.browser.tabs.executeScript).toHaveBeenCalledTimes(1);
-      expect(global.browser.notifications.create).toHaveBeenCalledTimes(1);
-    });
-    it('should show error notification if browser.tabs.executeScript threw an error', async () => {
-      when(global.browser.tabs.executeScript)
-        .calledWith(expect.any(Object))
-        .mockRejectedValue(new Error('test') as never);
-      expect(
-        await clearLocalStorageForThisDomain(initialState, sampleTab),
-      ).toBe(false);
-      expect(global.browser.tabs.executeScript).toHaveBeenCalledTimes(1);
-      expect(spyLib.throwErrorNotification).toHaveBeenCalledTimes(1);
-      expect(spyLib.showNotification).toHaveBeenCalledTimes(1);
-    });
-    it('should only show the no cleanup done notification if browser.tabs.executeScript threw a non-error type', async () => {
-      when(global.browser.tabs.executeScript)
-        .calledWith(expect.any(Object))
-        .mockRejectedValue('error' as never);
-      expect(
-        await clearLocalStorageForThisDomain(initialState, sampleTab),
-      ).toBe(false);
-      expect(global.browser.tabs.executeScript).toHaveBeenCalledTimes(1);
-      expect(spyLib.throwErrorNotification).not.toHaveBeenCalled();
-      expect(spyLib.showNotification).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/services/ContextMenuEvents.spec.ts
+++ b/__tests__/services/ContextMenuEvents.spec.ts
@@ -213,9 +213,6 @@ describe('ContextMenuEvents', () => {
       when(spyCleanupService.clearCookiesForThisDomain)
         .calledWith(expect.any(Object), expect.any(Object))
         .mockResolvedValue(true as never);
-      when(spyCleanupService.clearLocalStorageForThisDomain)
-        .calledWith(expect.any(Object), expect.any(Object))
-        .mockResolvedValue(true as never);
     });
     it('should show warning through cadLog if menuId given is unknown', () => {
       ContextMenuEvents.onContextMenuClicked(defaultOnClickData, sampleTab);
@@ -329,9 +326,11 @@ describe('ContextMenuEvents', () => {
         },
         sampleTab,
       );
-      expect(
-        spyCleanupService.clearLocalStorageForThisDomain,
-      ).toHaveBeenCalledTimes(1);
+      expect(spyCleanupService.clearSiteDataForThisDomain).toHaveBeenCalledWith(
+        expect.any(Object),
+        'LocalStorage',
+        expect.any(String),
+      );
     });
     it('Trigger Clear Plugin Data For This Domain', () => {
       ContextMenuEvents.onContextMenuClicked(

--- a/__tests__/setup.js
+++ b/__tests__/setup.js
@@ -122,7 +122,6 @@ const apis = {
     fn: [
       'connect',
       'create',
-      'executeScript',
       'get',
       'getCurrent',
       'query',

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "default_locale": "en",
   "homepage_url": "https://github.com/vasilisplavos/Cookie-AutoDeleteV3",
   "author": "Vasilis Plavos",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-autodelete-v3",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Chrome browser extension that auto-deletes unwanted cookies and site data",
   "keywords": [
     "cookie",

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -31,7 +31,6 @@ import {
   showNotification,
   siteDataToBrowser,
   SITEDATATYPES,
-  sleep,
   throwErrorNotification,
   trimDot,
   undefinedIsTrue,
@@ -500,57 +499,6 @@ export const clearCookiesForThisDomain = async (
   );
 
   return cookies.length > 0;
-};
-
-export const clearLocalStorageForThisDomain = async (
-  state: State,
-  tab: browser.tabs.Tab,
-): Promise<boolean> => {
-  // Using this method to ensure cross browser compatibility
-  try {
-    let local = 0;
-    let session = 0;
-    const result = await browser.tabs.executeScript({
-      code: `var cad_r = {local: window.localStorage.length, session: window.sessionStorage.length};window.localStorage.clear();window.sessionStorage.clear();cad_r;`,
-    });
-    result.forEach((frame: { [key: string]: any }) => {
-      local += frame.local;
-      session += frame.session;
-    });
-    showNotification(
-      {
-        duration: getSetting(state, SettingID.NOTIFY_DURATION) as number,
-        msg: `${browser.i18n.getMessage('manualCleanSuccess', [
-          browser.i18n.getMessage('localStorageText'),
-          getHostname(tab.url),
-        ])}\n${browser.i18n.getMessage('removeStorageCount', [
-          local.toString(),
-          browser.i18n.getMessage('localStorageText'),
-        ])}\n${browser.i18n.getMessage('removeStorageCount', [
-          session.toString(),
-          browser.i18n.getMessage('sessionStorageText'),
-        ])}`,
-      },
-      getSetting(state, SettingID.NOTIFY_MANUAL) as boolean,
-    );
-    return true;
-  } catch (e: unknown) {
-    if (e instanceof Error) {
-      throwErrorNotification(
-        e,
-        getSetting(state, SettingID.NOTIFY_DURATION) as number,
-      );
-    }
-    await sleep(750);
-    showNotification({
-      duration: getSetting(state, SettingID.NOTIFY_DURATION) as number,
-      msg: `${browser.i18n.getMessage('manualCleanNothing', [
-        browser.i18n.getMessage('localStorageText'),
-        getHostname(tab.url),
-      ])}`,
-    });
-    return false;
-  }
 };
 
 export const clearSiteDataForThisDomain = async (

--- a/src/services/ContextMenuEvents.ts
+++ b/src/services/ContextMenuEvents.ts
@@ -19,7 +19,6 @@ import {
 } from '../redux/Actions';
 import {
   clearCookiesForThisDomain,
-  clearLocalStorageForThisDomain,
   clearSiteDataForThisDomain,
 } from './CleanupService';
 import {
@@ -432,6 +431,7 @@ export default class ContextMenuEvents extends StoreUser {
         case SiteDataType.CACHE:
         case SiteDataType.FILESYSTEMS:
         case SiteDataType.INDEXEDDB:
+        case SiteDataType.LOCALSTORAGE:
         case SiteDataType.PLUGINDATA:
         case SiteDataType.SERVICEWORKERS:
           await clearSiteDataForThisDomain(
@@ -439,9 +439,6 @@ export default class ContextMenuEvents extends StoreUser {
             siteData,
             hostname,
           );
-          break;
-        case SiteDataType.LOCALSTORAGE:
-          await clearLocalStorageForThisDomain(StoreUser.store.getState(), tab);
           break;
         default:
           cadLog(

--- a/src/ui/popup/components/CleanCollapseGroup.tsx
+++ b/src/ui/popup/components/CleanCollapseGroup.tsx
@@ -16,10 +16,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Dispatch } from 'redux';
 import { cookieCleanupUI } from '../../../redux/Actions';
-import {
-  clearCookiesForThisDomain,
-  clearLocalStorageForThisDomain,
-} from '../../../services/CleanupService';
+import { clearCookiesForThisDomain } from '../../../services/CleanupService';
 import { ReduxAction } from '../../../typings/ReduxConstants';
 import { isChrome, isFirefoxNotAndroid } from '../../../services/Libs';
 import CleanDataButton from './CleanDataButton';
@@ -96,9 +93,6 @@ const CleanCollapseGroup: React.FunctionComponent<CleanCollapseComponentProps> =
             hostname={hostname}
           />
           <CleanDataButton
-            onClick={async () => {
-              return await clearLocalStorageForThisDomain(state, tab);
-            }}
             siteData={SiteDataType.LOCALSTORAGE}
             hostname={hostname}
           />

--- a/src/ui/popup/components/CleanDataButton.tsx
+++ b/src/ui/popup/components/CleanDataButton.tsx
@@ -15,7 +15,6 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import {
   clearCookiesForThisDomain,
-  clearLocalStorageForThisDomain,
   clearSiteDataForThisDomain,
 } from '../../../services/CleanupService';
 import { animateFlash } from '../popupLib';
@@ -46,11 +45,7 @@ const cleanSiteDataUI = async (
   if (siteData === 'All') {
     if (!tab) return false;
     const cookieSuccess = await clearCookiesForThisDomain(state, tab);
-    const localStorageSuccess = await clearLocalStorageForThisDomain(
-      state,
-      tab,
-    );
-    result = result || cookieSuccess || localStorageSuccess;
+    result = result || cookieSuccess;
   }
   return result;
 };

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -1,13 +1,6 @@
 {
   "releases": [
     {
-      "version": "1.2.1",
-      "notes": [
-        "Manual 'Clean LocalStorage' for a site now works again on Chromium browsers — it previously relied on a Manifest V2 API that no longer exists in MV3, so the button silently did nothing.",
-        "Removed the non-functional sessionStorage cleanup — sessionStorage is per-tab and is already cleared by the browser when the tab closes."
-      ]
-    },
-    {
       "version": "1.2.0",
       "notes": [
         "New 'File System' site-data cleanup (Chromium browsers) — clears File System API data that sites like mega.nz leave behind in your profile. Plugin Data cleanup is now hidden on Chromium, since it's deprecated there and no longer has any effect.",

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -1,6 +1,13 @@
 {
   "releases": [
     {
+      "version": "1.2.1",
+      "notes": [
+        "Manual 'Clean LocalStorage' for a site now works again on Chromium browsers — it previously relied on a Manifest V2 API that no longer exists in MV3, so the button silently did nothing.",
+        "Removed the non-functional sessionStorage cleanup — sessionStorage is per-tab and is already cleared by the browser when the tab closes."
+      ]
+    },
+    {
       "version": "1.2.0",
       "notes": [
         "New 'File System' site-data cleanup (Chromium browsers) — clears File System API data that sites like mega.nz leave behind in your profile. Plugin Data cleanup is now hidden on Chromium, since it's deprecated there and no longer has any effect.",


### PR DESCRIPTION
## Summary

Manual **Clean LocalStorage** was silently a no-op on Chromium MV3: `clearLocalStorageForThisDomain` used `browser.tabs.executeScript`, a **Manifest V2 API removed in MV3** (undefined → throws → swallowed by the `catch` → "nothing to clean"). sessionStorage — which only lived inside that same function — was never cleared either.

This reroutes all three manual localStorage trigger paths through the already-working `browsingData` API and deletes the dead MV2 code.

## Changes

- **Popup "Clean LocalStorage" button** (`CleanCollapseGroup.tsx`) → falls through to `CleanDataButton`'s default `clearSiteDataForThisDomain(state, LOCALSTORAGE, hostname)` (`browser.browsingData.remove`, MV3-supported), like every other site-data button.
- **"All" combined-clean path** (`CleanDataButton.tsx`) → removed the redundant + broken `clearLocalStorageForThisDomain` call. `clearSiteDataForThisDomain('All')` already loops `SITEDATATYPES` (which includes `LOCALSTORAGE`); cookies stay on their own `chrome.cookies` path.
- **Context menu** (`ContextMenuEvents.ts`) → folded the `LOCALSTORAGE` case into the shared `clearSiteDataForThisDomain` switch branch (test updated, test-first).
- **Deleted** `clearLocalStorageForThisDomain` + its now-unused `sleep` import + obsolete tests + the `executeScript` test mock.
- **Dropped sessionStorage cleanup** deliberately — it is per-tab and cleared by the browser on tab close; keeping it would require the `scripting` permission, which we reject. **No new permissions.**
- Version bump **1.2.0 → 1.2.1** + ReleaseNotes entry.

## Why not `scripting`

Automatic localStorage cleanup (tab-close / startup) already worked via `browsingData` and is untouched. localStorage removal never needed `scripting` — only the injection-based sessionStorage clear did, and that feature is dropped. Cleaner privacy story, zero permission cost.

## Testing

- `npm run test-all`: **556 tests pass, 0 lint warnings** (eslint `--max-warnings 0`).
- Context-menu localStorage routing covered test-first (RED → GREEN).
- Repo-wide grep confirms **zero** remaining references to `browser.tabs.executeScript` or `clearLocalStorageForThisDomain`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)