### PR TITLE
perf: fix three background hot paths, plus a measurement harness

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ builds/
 # 3rd-Party Files copied from npm
 extension/global_files/browser-polyfill.min.js*
 /.playwright-mcp
+
+# Perf measurement run data (baseline/ is tracked, ad-hoc runs are not)
+/tools/perf/runs/

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ extension/global_files/browser-polyfill.min.js*
 
 # Perf measurement run data (baseline/ is tracked, ad-hoc runs are not)
 /tools/perf/runs/
+
+# Subagent-driven-development scratch (ledger, briefs, review packages)
+/.superpowers/

--- a/__tests__/background/lifecycle.spec.ts
+++ b/__tests__/background/lifecycle.spec.ts
@@ -32,8 +32,9 @@ jest.mock('../../src/services/ContextualIdentitiesEvents', () => {
   };
 });
 
-import { ready, _resetForTests } from '../../src/background/lifecycle';
+import { getStore, ready, _resetForTests } from '../../src/background/lifecycle';
 import { PARTITION_PROBE_COOKIE_NAME } from '../../src/services/Libs';
+import { ReduxConstants } from '../../src/typings/ReduxConstants';
 
 describe('background/lifecycle', () => {
   beforeEach(() => {
@@ -145,6 +146,51 @@ describe('background/lifecycle', () => {
       await ready();
       expect(bas.setGlobalIcon).toHaveBeenCalled();
       expect(bas.resetAllTabIcons).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('store subscriptions', () => {
+    it('does not run SettingService.onSettingsChange for an unrelated slice', async () => {
+      await ready();
+      const SettingService = require('../../src/services/SettingService').default;
+      const before = SettingService.onSettingsChange.mock.calls.length;
+
+      getStore().dispatch({
+        type: ReduxConstants.ADD_CACHE,
+        payload: { key: 'probe', value: 1 },
+      });
+
+      expect(SettingService.onSettingsChange.mock.calls.length).toBe(before);
+    });
+
+    it('runs SettingService.onSettingsChange when settings change', async () => {
+      await ready();
+      const SettingService = require('../../src/services/SettingService').default;
+      const before = SettingService.onSettingsChange.mock.calls.length;
+
+      getStore().dispatch({
+        type: ReduxConstants.UPDATE_SETTING,
+        payload: { name: SettingID.DEBUG_MODE, value: true },
+      });
+
+      expect(SettingService.onSettingsChange.mock.calls.length).toBe(before + 1);
+    });
+
+    it('refreshes the action icon when the expression lists change', async () => {
+      await ready();
+      const bas = require('../../src/services/BrowserActionService');
+      const before = bas.checkIfProtected.mock.calls.length;
+
+      getStore().dispatch({
+        type: ReduxConstants.ADD_EXPRESSION,
+        payload: {
+          expression: '*.example.com',
+          listType: ListType.WHITE,
+          storeId: 'default',
+        },
+      });
+
+      expect(bas.checkIfProtected.mock.calls.length).toBe(before + 1);
     });
   });
 });

--- a/__tests__/background/lifecycle.spec.ts
+++ b/__tests__/background/lifecycle.spec.ts
@@ -176,6 +176,19 @@ describe('background/lifecycle', () => {
       expect(SettingService.onSettingsChange.mock.calls.length).toBe(before + 1);
     });
 
+    it('does not run checkIfProtected for an unrelated slice', async () => {
+      await ready();
+      const bas = require('../../src/services/BrowserActionService');
+      const before = bas.checkIfProtected.mock.calls.length;
+
+      getStore().dispatch({
+        type: ReduxConstants.ADD_CACHE,
+        payload: { key: 'probe', value: 1 },
+      });
+
+      expect(bas.checkIfProtected.mock.calls.length).toBe(before);
+    });
+
     it('refreshes the action icon when the expression lists change', async () => {
       await ready();
       const bas = require('../../src/services/BrowserActionService');

--- a/__tests__/background/lifecycle.spec.ts
+++ b/__tests__/background/lifecycle.spec.ts
@@ -9,6 +9,7 @@ import { when } from 'jest-when';
 // Mock heavy services so the test only focuses on lifecycle logic
 jest.mock('../../src/services/BrowserActionService', () => ({
   setGlobalIcon: jest.fn().mockResolvedValue(undefined),
+  resetAllTabIcons: jest.fn().mockResolvedValue(undefined),
   checkIfProtected: jest.fn().mockResolvedValue(undefined),
 }));
 jest.mock('../../src/services/SettingService', () => {
@@ -137,6 +138,13 @@ describe('background/lifecycle', () => {
       global.browser.cookies.getAll = jest.fn();
       await ready();
       expect(global.browser.cookies.getAll).not.toHaveBeenCalled();
+    });
+
+    it('does not touch per-tab icons during init', async () => {
+      const bas = require('../../src/services/BrowserActionService');
+      await ready();
+      expect(bas.setGlobalIcon).toHaveBeenCalled();
+      expect(bas.resetAllTabIcons).not.toHaveBeenCalled();
     });
   });
 });

--- a/__tests__/background/lifecycle.spec.ts
+++ b/__tests__/background/lifecycle.spec.ts
@@ -205,5 +205,25 @@ describe('background/lifecycle', () => {
 
       expect(bas.checkIfProtected.mock.calls.length).toBe(before + 1);
     });
+
+    // The raw-dispatch test above cannot see a double call: the UI reaches these
+    // actions through the Actions.ts thunks, which used to run their own
+    // checkIfProtected on top of this subscription.
+    it('runs checkIfProtected exactly once for a list edit made through the thunk', async () => {
+      await ready();
+      const bas = require('../../src/services/BrowserActionService');
+      const { addExpression } = require('../../src/redux/Actions');
+      const before = bas.checkIfProtected.mock.calls.length;
+
+      getStore().dispatch(
+        addExpression({
+          expression: '*.thunk-path.com',
+          listType: ListType.WHITE,
+          storeId: 'default',
+        }),
+      );
+
+      expect(bas.checkIfProtected.mock.calls.length).toBe(before + 1);
+    });
   });
 });

--- a/__tests__/perf/hotpaths.test.ts
+++ b/__tests__/perf/hotpaths.test.ts
@@ -1,0 +1,299 @@
+/**
+ * Hot-path measurement harness.
+ *
+ * Runs the REAL background code (lifecycle.init, TabEvents, CookieEvents,
+ * SettingService) against an instrumented `browser.*` mock and reports:
+ *   - exact extension-API (IPC) call counts per event
+ *   - real JS CPU time per event, measured on this machine
+ *
+ * It does NOT measure browser-process IPC latency (not observable from Node);
+ * call counts are reported so that cost can be applied separately.
+ */
+
+/* eslint-disable @typescript-eslint/no-var-requires, @typescript-eslint/no-explicit-any, no-console */
+
+import { ReduxConstants } from '../../src/typings/ReduxConstants';
+
+const perf = require('../../tools/perf/instrumentedBrowser');
+
+// setup.js replaces global.console with jest.fn()s but keeps the originals.
+const out: (...a: unknown[]) => void =
+  (global.console as any)._log || console.log;
+
+const HR = () => process.hrtime.bigint();
+const MS = (a: bigint, b: bigint) => Number(b - a) / 1e6;
+
+function median(xs: number[]): number {
+  const s = [...xs].sort((a, b) => a - b);
+  const m = Math.floor(s.length / 2);
+  return s.length % 2 ? s[m] : (s[m - 1] + s[m]) / 2;
+}
+
+function fmt(n: number, d = 3): string {
+  return n.toFixed(d);
+}
+
+/** Non-zero call counts, sorted desc, as "name×n" */
+function callSummary(calls: Record<string, number>): string {
+  return Object.entries(calls)
+    .filter(([, v]) => v > 0)
+    .sort((a, b) => b[1] - a[1])
+    .map(([k, v]) => `${k}×${v}`)
+    .join(', ');
+}
+
+/** Drain pending microtasks + timers so async subscribers finish. */
+const drain = () => new Promise<void>((r) => setTimeout(r, 0));
+
+/**
+ * jest.resetModules() gives each measurement a fresh lifecycle module, and each
+ * one arms its own 1 s save debounce. Keep every instance so afterAll can clear
+ * them rather than leaving timers armed past the suite.
+ */
+const lifecycles: Array<{ _resetForTests: () => void }> = [];
+function requireLifecycle(): any {
+  const mod = require('../../src/background/lifecycle');
+  lifecycles.push(mod);
+  return mod;
+}
+
+/**
+ * A realistic "returning user" stored state: default settings plus a populated
+ * whitelist/greylist. Built once from the real reducers.
+ */
+function buildSeedState(expressionCount: number): string {
+  jest.resetModules();
+  perf.install({ tabCount: 1 });
+  const createStore = require('../../src/redux/Store').default;
+  const store = createStore({});
+  store.dispatch({ type: ReduxConstants.ON_STARTUP });
+  for (let i = 0; i < expressionCount; i++) {
+    store.dispatch({
+      type: ReduxConstants.ADD_EXPRESSION,
+      payload: {
+        expression: `*.site-${i}.com`,
+        listType: i % 3 === 0 ? ListType.GREY : ListType.WHITE,
+        storeId: 'default',
+        cleanSiteData: i % 2 === 0 ? [SiteDataType.LOCALSTORAGE] : [],
+      },
+    });
+  }
+  return JSON.stringify(store.getState());
+}
+
+interface ColdResult {
+  ms: number;
+  calls: Record<string, number>;
+  total: number;
+}
+
+async function measureColdInit(
+  tabCount: number,
+  seed: string,
+): Promise<ColdResult> {
+  jest.resetModules();
+  const env = perf.install({ tabCount });
+  env.storageLocal.data.state = seed;
+  perf.resetCalls();
+
+  const lifecycle = requireLifecycle();
+  const t0 = HR();
+  await lifecycle.ready();
+  const t1 = HR();
+  await drain();
+
+  return { ms: MS(t0, t1), calls: { ...perf.calls }, total: perf.totalCalls() };
+}
+
+jest.setTimeout(120000);
+
+describe('CAD hot-path measurements', () => {
+  const SEED = buildSeedState(20);
+
+  afterAll(() => {
+    for (const l of lifecycles) l._resetForTests();
+  });
+
+  it('M1 — cold service-worker init vs open-tab count', async () => {
+    out('\n' + '='.repeat(78));
+    out('M1  COLD SW INIT  (lifecycle.ready() — runs on every SW wake)');
+    out('='.repeat(78));
+    out(
+      `seed state: ${(SEED.length / 1024).toFixed(1)} KB JSON, 20 expressions\n`,
+    );
+    out(
+      'tabs |  CPU ms (median of 7)  |  ext API calls  |  breakdown',
+    );
+    out('-'.repeat(78));
+
+    const rows: Array<[number, number, number, string]> = [];
+    for (const tabCount of [1, 10, 30, 60]) {
+      const runs: ColdResult[] = [];
+      for (let i = 0; i < 7; i++) {
+        runs.push(await measureColdInit(tabCount, SEED));
+      }
+      const ms = median(runs.map((r) => r.ms));
+      const last = runs[runs.length - 1];
+      rows.push([tabCount, ms, last.total, callSummary(last.calls)]);
+      out(
+        `${String(tabCount).padStart(4)} | ${fmt(ms).padStart(20)}  | ${String(
+          last.total,
+        ).padStart(15)}  | ${callSummary(last.calls)}`,
+      );
+    }
+
+    out('');
+    const [t1, t60] = [rows[0], rows[3]];
+    out(
+      `scaling: ${t1[0]} tab = ${fmt(t1[1])} ms / ${t1[2]} calls  ->  ${
+        t60[0]
+      } tabs = ${fmt(t60[1])} ms / ${t60[2]} calls`,
+    );
+    out(
+      `per extra tab: +${fmt(
+        (t60[1] - t1[1]) / (t60[0] - t1[0]),
+      )} ms CPU, +${fmt((t60[2] - t1[2]) / (t60[0] - t1[0]), 2)} API calls`,
+    );
+    expect(rows.length).toBe(4);
+  });
+
+  it('M2 — cookies.onChanged: cost paid by EVERY cookie write in the browser', async () => {
+    jest.resetModules();
+    const env = perf.install({ tabCount: 30 });
+    env.storageLocal.data.state = SEED;
+    const lifecycle = requireLifecycle();
+    await lifecycle.ready();
+    await drain();
+    const CookieEvents = require('../../src/services/CookieEvents').default;
+
+    const activeTab = env.tabs.find((t: any) => t.active);
+    const activeDomain = new URL(activeTab.url).hostname.replace(/^www\./, '');
+
+    const cases: Array<[string, string]> = [
+      ['matches active tab', activeDomain],
+      ['unrelated 3rd-party', 'tracker.adnetwork-example.com'],
+    ];
+
+    out('\n' + '='.repeat(78));
+    out('M2  cookies.onChanged  (fires on every cookie set/overwrite/delete)');
+    out('='.repeat(78));
+    out('case                  | CPU us/event | ext API calls/event | which');
+    out('-'.repeat(78));
+
+    const results: Array<[string, number, number]> = [];
+    for (const [label, domain] of cases) {
+      const N = 300;
+      // warm-up
+      for (let i = 0; i < 50; i++) {
+        await CookieEvents.onCookieChanged({
+          removed: false,
+          cause: 'explicit',
+          cookie: perf.makeCookie(i, domain),
+        });
+      }
+      perf.resetCalls();
+      const t0 = HR();
+      for (let i = 0; i < N; i++) {
+        await CookieEvents.onCookieChanged({
+          removed: false,
+          cause: 'explicit',
+          cookie: perf.makeCookie(i, domain),
+        });
+      }
+      const t1 = HR();
+      const usPer = (MS(t0, t1) * 1000) / N;
+      const callsPer = perf.totalCalls() / N;
+      results.push([label, usPer, callsPer]);
+      out(
+        `${label.padEnd(21)} | ${fmt(usPer, 1).padStart(12)} | ${fmt(
+          callsPer,
+          2,
+        ).padStart(19)} | ${callSummary(perf.calls)}`,
+      );
+    }
+    out('');
+    out(
+      'NOTE: the 750 ms debounce in TabEvents.onTabUpdate suppresses the downstream',
+    );
+    out(
+      '      work, but tabs.query above is paid unconditionally, per event.',
+    );
+    expect(results.length).toBe(2);
+  });
+
+  it('M3 — getAllCookieActions: per page-load work (debounced, <=1.3/s)', async () => {
+    jest.resetModules();
+    const env = perf.install({ tabCount: 30, cookiesPerDomain: 25 });
+    env.storageLocal.data.state = SEED;
+    const lifecycle = requireLifecycle();
+    await lifecycle.ready();
+    await drain();
+    const TabEvents = require('../../src/services/TabEvents').default;
+
+    const tab = env.tabs[0];
+    for (let i = 0; i < 30; i++) await TabEvents.getAllCookieActions(tab);
+    await drain();
+
+    const N = 200;
+    perf.resetCalls();
+    const t0 = HR();
+    for (let i = 0; i < N; i++) await TabEvents.getAllCookieActions(tab);
+    const t1 = HR();
+    await drain();
+
+    out('\n' + '='.repeat(78));
+    out('M3  TabEvents.getAllCookieActions  (per completed page load)');
+    out('='.repeat(78));
+    out(`CPU: ${fmt((MS(t0, t1) * 1000) / N, 1)} us/call`);
+    out(`ext API calls: ${fmt(perf.totalCalls() / N, 2)} per call`);
+    out(`breakdown: ${callSummary(perf.calls)}`);
+    expect(perf.totalCalls()).toBeGreaterThan(0);
+  });
+
+  it('M4 — store dispatch overhead (SettingService.onSettingsChange on EVERY dispatch)', async () => {
+    jest.resetModules();
+    const env = perf.install({ tabCount: 30 });
+    env.storageLocal.data.state = SEED;
+    const lifecycle = requireLifecycle();
+    await lifecycle.ready();
+    await drain();
+    const store = lifecycle.getStore();
+
+    // warm-up
+    for (let i = 0; i < 30; i++) {
+      store.dispatch({
+        type: ReduxConstants.ADD_CACHE,
+        payload: { key: `warm${i}`, value: i },
+      });
+    }
+    await drain();
+
+    const N = 200;
+    perf.resetCalls();
+    const t0 = HR();
+    for (let i = 0; i < N; i++) {
+      store.dispatch({
+        type: ReduxConstants.ADD_CACHE,
+        payload: { key: `k${i}`, value: i },
+      });
+    }
+    const t1 = HR();
+    const syncMs = MS(t0, t1);
+    await drain();
+    await drain();
+    const t2 = HR();
+
+    out('\n' + '='.repeat(78));
+    out('M4  ONE redux dispatch  (any state change: cache, activity log, counters)');
+    out('='.repeat(78));
+    out(`sync CPU on the dispatch stack : ${fmt((syncMs * 1000) / N, 1)} us/dispatch`);
+    out(`total incl. async subscribers  : ${fmt((MS(t0, t2) * 1000) / N, 1)} us/dispatch`);
+    out(`ext API calls                  : ${fmt(perf.totalCalls() / N, 2)} per dispatch`);
+    out(`breakdown: ${callSummary(perf.calls)}`);
+    out('');
+    out('This is lifecycle.ts:141 -> SettingService.onSettingsChange, which ends in');
+    out('checkIfProtected() + validateSettings() on EVERY store change, not just');
+    out('on settings changes.');
+    expect(perf.totalCalls()).toBeGreaterThan(0);
+  });
+});

--- a/__tests__/perf/hotpaths.test.ts
+++ b/__tests__/perf/hotpaths.test.ts
@@ -250,7 +250,7 @@ describe('CAD hot-path measurements', () => {
     expect(perf.totalCalls()).toBeGreaterThan(0);
   });
 
-  it('M4 — store dispatch overhead (SettingService.onSettingsChange on EVERY dispatch)', async () => {
+  it('M4 — store dispatch overhead (subscribers are slice-scoped, Task 2)', async () => {
     jest.resetModules();
     const env = perf.install({ tabCount: 30 });
     env.storageLocal.data.state = SEED;
@@ -259,6 +259,13 @@ describe('CAD hot-path measurements', () => {
     await drain();
     const store = lifecycle.getStore();
 
+    out('\n' + '='.repeat(78));
+    out('M4  REDUX DISPATCH  (lifecycle.ts subscribes SettingService.onSettingsChange');
+    out('    to the `settings` slice only, and checkIfProtected to `lists` only —');
+    out('    via onSlicesChange — instead of running both on every dispatch)');
+    out('='.repeat(78));
+
+    // --- Part A: a slice neither subscriber reads (cache) ------------------
     // warm-up
     for (let i = 0; i < 30; i++) {
       store.dispatch({
@@ -270,30 +277,74 @@ describe('CAD hot-path measurements', () => {
 
     const N = 200;
     perf.resetCalls();
-    const t0 = HR();
+    let t0 = HR();
     for (let i = 0; i < N; i++) {
       store.dispatch({
         type: ReduxConstants.ADD_CACHE,
         payload: { key: `k${i}`, value: i },
       });
     }
-    const t1 = HR();
-    const syncMs = MS(t0, t1);
+    let t1 = HR();
+    const unrelatedSyncMs = MS(t0, t1);
     await drain();
     await drain();
-    const t2 = HR();
+    let t2 = HR();
 
-    out('\n' + '='.repeat(78));
-    out('M4  ONE redux dispatch  (any state change: cache, activity log, counters)');
-    out('='.repeat(78));
-    out(`sync CPU on the dispatch stack : ${fmt((syncMs * 1000) / N, 1)} us/dispatch`);
-    out(`total incl. async subscribers  : ${fmt((MS(t0, t2) * 1000) / N, 1)} us/dispatch`);
-    out(`ext API calls                  : ${fmt(perf.totalCalls() / N, 2)} per dispatch`);
-    out(`breakdown: ${callSummary(perf.calls)}`);
+    out(`ADD_CACHE (unrelated slice) x${N}:`);
+    out(
+      `  sync CPU on the dispatch stack : ${fmt((unrelatedSyncMs * 1000) / N, 1)} us/dispatch`,
+    );
+    out(
+      `  total incl. async subscribers  : ${fmt((MS(t0, t2) * 1000) / N, 1)} us/dispatch`,
+    );
+    out(`  ext API calls                  : ${perf.totalCalls()} total`);
+    out(
+      '  onSlicesChange filters this out before SettingService.onSettingsChange or',
+    );
+    out('  checkIfProtected ever run — this is Task 2\'s intended effect.');
+
+    expect(perf.totalCalls()).toBe(0);
+
+    // --- Part B: the settings slice, which onSettingsChange DOES read ------
+    for (let i = 0; i < 5; i++) {
+      store.dispatch({
+        type: ReduxConstants.UPDATE_SETTING,
+        payload: { name: SettingID.DEBUG_MODE, value: i % 2 === 0 },
+      });
+    }
+    await drain();
+
+    perf.resetCalls();
+    t0 = HR();
+    for (let i = 0; i < N; i++) {
+      store.dispatch({
+        type: ReduxConstants.UPDATE_SETTING,
+        payload: { name: SettingID.DEBUG_MODE, value: i % 2 === 0 },
+      });
+    }
+    t1 = HR();
+    const settingsSyncMs = MS(t0, t1);
+    await drain();
+    await drain();
+    t2 = HR();
+
     out('');
-    out('This is lifecycle.ts:141 -> SettingService.onSettingsChange, which ends in');
-    out('checkIfProtected() + validateSettings() on EVERY store change, not just');
-    out('on settings changes.');
+    out(`UPDATE_SETTING (settings slice) x${N}:`);
+    out(
+      `  sync CPU on the dispatch stack : ${fmt((settingsSyncMs * 1000) / N, 1)} us/dispatch`,
+    );
+    out(
+      `  total incl. async subscribers  : ${fmt((MS(t0, t2) * 1000) / N, 1)} us/dispatch`,
+    );
+    out(
+      `  ext API calls                  : ${fmt(perf.totalCalls() / N, 2)} per dispatch`,
+    );
+    out(`  breakdown: ${callSummary(perf.calls)}`);
+    out(
+      '  This is SettingService.onSettingsChange -> checkIfProtected(), which now',
+    );
+    out('  only runs when the settings slice actually changed identity.');
+
     expect(perf.totalCalls()).toBeGreaterThan(0);
   });
 });

--- a/__tests__/perf/hotpaths.test.ts
+++ b/__tests__/perf/hotpaths.test.ts
@@ -276,6 +276,11 @@ describe('CAD hot-path measurements', () => {
     await drain();
 
     const N = 200;
+    // ready() + the warm-up above already dirtied state and armed lifecycle's
+    // 1 s save-debounce timer. If it fires inside the measured window below
+    // it adds two storage.*.set calls unrelated to what this asserts -- clear
+    // it so the loop gets a fresh ~1 s budget instead of whatever's left.
+    lifecycle._resetForTests();
     perf.resetCalls();
     let t0 = HR();
     for (let i = 0; i < N; i++) {

--- a/__tests__/services/BrowserActionService.spec.ts
+++ b/__tests__/services/BrowserActionService.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright (c) 2026 Vasilis Plavos
+ * Licensed under MIT
+ */
+
+import { when } from 'jest-when';
+import {
+  resetAllTabIcons,
+  setGlobalIcon,
+} from '../../src/services/BrowserActionService';
+
+const stubIconGlobals = (): void => {
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    blob: () => Promise.resolve({}),
+  });
+  (global as any).createImageBitmap = jest
+    .fn()
+    .mockResolvedValue({ width: 48, height: 48 });
+  (global as any).OffscreenCanvas = class {
+    public getContext(): unknown {
+      return {
+        drawImage: (): void => undefined,
+        getImageData: (_x: number, _y: number, w: number, h: number) => ({
+          width: w,
+          height: h,
+          data: new Uint8ClampedArray(w * h * 4),
+        }),
+      };
+    }
+  };
+};
+
+describe('BrowserActionService', () => {
+  beforeEach(() => {
+    stubIconGlobals();
+    global.browser.runtime.getURL = jest.fn((p: string) => `chrome-extension://x/${p}`);
+  });
+
+  describe('setGlobalIcon()', () => {
+    it('writes the default icon once and never touches per-tab icons', async () => {
+      await setGlobalIcon(true);
+
+      expect(global.browser.action.setIcon).toHaveBeenCalledTimes(1);
+      expect(global.browser.action.setIcon).toHaveBeenCalledWith(
+        expect.not.objectContaining({ tabId: expect.anything() }),
+      );
+      expect(global.browser.tabs.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('resetAllTabIcons()', () => {
+    it('writes the default icon and overwrites every open tab', async () => {
+      when(global.browser.tabs.query)
+        .calledWith({ windowType: 'normal' })
+        .mockResolvedValue([{ id: 1 }, { id: 2 }, { id: 3 }] as never);
+
+      await resetAllTabIcons(false);
+
+      // 1 default write + 3 per-tab writes
+      expect(global.browser.action.setIcon).toHaveBeenCalledTimes(4);
+      expect(global.browser.action.setIcon).toHaveBeenCalledWith(
+        expect.objectContaining({ tabId: 2 }),
+      );
+    });
+  });
+});

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -71,6 +71,14 @@ const mockCookie: browser.cookies.CookieProperties = {
 };
 
 describe('Library Functions', () => {
+  // isFirstPartyIsolate() memoises its result at module scope, and
+  // clearMocks does not touch that cache. Without this, whichever test runs
+  // first primes it for every test after — reset it file-wide so test order
+  // can't leak into unrelated specs.
+  beforeEach(() => {
+    _resetFirstPartyIsolateCache();
+  });
+
   describe('cadLog()', () => {
     beforeAll(() => {
       when(global.browser.runtime.getManifest)
@@ -1260,6 +1268,30 @@ describe('Library Functions', () => {
 
       expect(results).toEqual([false, false, false]);
       expect(global.browser.cookies.getAll).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cache an inconclusive error, and re-probes on the next call', async () => {
+      _resetFirstPartyIsolateCache();
+      (global.browser.cookies.getAll as jest.Mock).mockReset();
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: '' })
+        .mockRejectedValueOnce(new Error('transient network error') as never)
+        .mockRejectedValueOnce(new Error('firstPartyDomain') as never);
+
+      // First probe errors for a reason unrelated to FPI. It must still
+      // return the computed (false) value, but must NOT pin it -- otherwise
+      // this false gets cached for the rest of the service worker's life.
+      await expect(isFirstPartyIsolate()).resolves.toEqual(false);
+      expect(global.browser.cookies.getAll).toHaveBeenCalledTimes(1);
+
+      // Because the first outcome wasn't cached, the next call re-probes and
+      // gets the conclusive answer.
+      await expect(isFirstPartyIsolate()).resolves.toEqual(true);
+      expect(global.browser.cookies.getAll).toHaveBeenCalledTimes(2);
+
+      // The conclusive `true` IS cached: a third call must not probe again.
+      await expect(isFirstPartyIsolate()).resolves.toEqual(true);
+      expect(global.browser.cookies.getAll).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -38,6 +38,7 @@ import {
   isFirefoxAndroid,
   isFirefoxNotAndroid,
   isFirstPartyIsolate,
+  _resetFirstPartyIsolateCache,
   localFileToRegex,
   matchIPInExpression,
   PARTITION_PROBE_COOKIE_NAME,
@@ -1214,6 +1215,7 @@ describe('Library Functions', () => {
 
   describe('isFirstPartyIsolate()', () => {
     beforeEach(() => {
+      _resetFirstPartyIsolateCache();
       when(global.browser.cookies.getAll)
         .calledWith({ domain: '' })
         .mockResolvedValueOnce([] as never)
@@ -1228,6 +1230,23 @@ describe('Library Functions', () => {
     });
     it('should return false if error was caught and message did not contain "firstPartyIsolate"', () => {
       return expect(isFirstPartyIsolate()).resolves.toEqual(false);
+    });
+  });
+
+  describe('isFirstPartyIsolate() caching', () => {
+    it('probes once no matter how many times it is called', async () => {
+      _resetFirstPartyIsolateCache();
+      (global.browser.cookies.getAll as jest.Mock).mockReset();
+      (global.browser.cookies.getAll as jest.Mock).mockResolvedValue([]);
+
+      const results = await Promise.all([
+        isFirstPartyIsolate(),
+        isFirstPartyIsolate(),
+        isFirstPartyIsolate(),
+      ]);
+
+      expect(results).toEqual([false, false, false]);
+      expect(global.browser.cookies.getAll).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -1231,7 +1231,6 @@ describe('Library Functions', () => {
       // same matcher (e.g. getAllCookiesForDomain's FPI tests) -- an
       // unconsumed leftover there previously shifted these three tests by
       // one position. Each test below now owns its mock value outright.
-      _resetFirstPartyIsolateCache();
       (global.browser.cookies.getAll as jest.Mock).mockReset();
     });
     it('should return false if no error was caught', () => {
@@ -1256,7 +1255,6 @@ describe('Library Functions', () => {
 
   describe('isFirstPartyIsolate() caching', () => {
     it('probes once no matter how many times it is called', async () => {
-      _resetFirstPartyIsolateCache();
       (global.browser.cookies.getAll as jest.Mock).mockReset();
       (global.browser.cookies.getAll as jest.Mock).mockResolvedValue([]);
 
@@ -1271,7 +1269,6 @@ describe('Library Functions', () => {
     });
 
     it('does not cache an inconclusive error, and re-probes on the next call', async () => {
-      _resetFirstPartyIsolateCache();
       (global.browser.cookies.getAll as jest.Mock).mockReset();
       when(global.browser.cookies.getAll)
         .calledWith({ domain: '' })

--- a/__tests__/services/Libs.spec.ts
+++ b/__tests__/services/Libs.spec.ts
@@ -1215,20 +1215,33 @@ describe('Library Functions', () => {
 
   describe('isFirstPartyIsolate()', () => {
     beforeEach(() => {
+      // Fully reset the memoisation cache AND the mock's registered
+      // jest-when handlers before every test, rather than relying on a
+      // shared mockResolvedValueOnce/mockRejectedValueOnce queue. That
+      // queue is keyed only by call args ({ domain: '' }), so it also
+      // accumulates whatever other describes in this file push onto the
+      // same matcher (e.g. getAllCookiesForDomain's FPI tests) -- an
+      // unconsumed leftover there previously shifted these three tests by
+      // one position. Each test below now owns its mock value outright.
       _resetFirstPartyIsolateCache();
-      when(global.browser.cookies.getAll)
-        .calledWith({ domain: '' })
-        .mockResolvedValueOnce([] as never)
-        .mockRejectedValueOnce(new Error('firstPartyDomain') as never)
-        .mockRejectedValueOnce(new Error('Error') as never);
+      (global.browser.cookies.getAll as jest.Mock).mockReset();
     });
     it('should return false if no error was caught', () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: '' })
+        .mockResolvedValueOnce([] as never);
       return expect(isFirstPartyIsolate()).resolves.toEqual(false);
     });
     it('should return true if error was caught and message contained "firstPartyDomain"', () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: '' })
+        .mockRejectedValueOnce(new Error('firstPartyDomain') as never);
       return expect(isFirstPartyIsolate()).resolves.toEqual(true);
     });
     it('should return false if error was caught and message did not contain "firstPartyIsolate"', () => {
+      when(global.browser.cookies.getAll)
+        .calledWith({ domain: '' })
+        .mockRejectedValueOnce(new Error('Error') as never);
       return expect(isFirstPartyIsolate()).resolves.toEqual(false);
     });
   });

--- a/__tests__/services/SettingService.spec.ts
+++ b/__tests__/services/SettingService.spec.ts
@@ -166,16 +166,16 @@ describe('SettingService', () => {
     it('should enable global icon if active mode was recently enabled', async () => {
       TestStore.changeSetting(SettingID.ACTIVE_MODE, false);
       await SettingService.onSettingsChange();
-      spyBrowserActions.setGlobalIcon.mockClear();
+      spyBrowserActions.resetAllTabIcons.mockClear();
       TestStore.changeSetting(SettingID.ACTIVE_MODE, true);
       await SettingService.onSettingsChange();
-      expect(spyBrowserActions.setGlobalIcon).toHaveBeenCalledWith(true);
+      expect(spyBrowserActions.resetAllTabIcons).toHaveBeenCalledWith(true);
     });
     it('should make global icon greyscale and clear alarms if active mode was recently disabled', async () => {
       TestStore.changeSetting(SettingID.ACTIVE_MODE, false);
       await SettingService.onSettingsChange();
       expect(global.browser.alarms.clear).toHaveBeenCalledTimes(1);
-      expect(spyBrowserActions.setGlobalIcon).toHaveBeenCalledWith(false);
+      expect(spyBrowserActions.resetAllTabIcons).toHaveBeenCalledWith(false);
     });
     it('should clear contextMenus if recently disabled', async () => {
       TestStore.changeSetting(SettingID.CONTEXT_MENUS, false);

--- a/__tests__/services/TabEvents.spec.ts
+++ b/__tests__/services/TabEvents.spec.ts
@@ -393,6 +393,33 @@ describe('TabEvents', () => {
     });
   });
 
+  describe('onTabActivated', () => {
+    it('repaints the action icon for the newly activated tab', async () => {
+      const tab = { ...sampleTab, id: 7, url: 'https://example.com' };
+      when(global.browser.tabs.get)
+        .calledWith(7)
+        .mockResolvedValue(tab as never);
+
+      await TabEvents.onTabActivated({ tabId: 7, windowId: 1 });
+
+      expect(spyBrowserActions.checkIfProtected).toHaveBeenCalledWith(
+        expect.anything(),
+        tab,
+      );
+    });
+
+    it('does not throw when the tab is already gone', async () => {
+      when(global.browser.tabs.get)
+        .calledWith(999)
+        .mockRejectedValue(new Error('No tab with id: 999') as never);
+
+      await expect(
+        TabEvents.onTabActivated({ tabId: 999, windowId: 1 }),
+      ).resolves.toBeUndefined();
+      expect(spyBrowserActions.checkIfProtected).not.toHaveBeenCalled();
+    });
+  });
+
   describe('onTabUpdate', () => {
     beforeAll(() => {
       when(spyTabEvents.getAllCookieActions)

--- a/jest.config.js
+++ b/jest.config.js
@@ -128,9 +128,12 @@ module.exports = {
   testMatch: ['**/__tests__/*/**.[jt]s?(x)', '**/?(*.)+(spec|test).[jt]s?(x)'],
 
   // An array of regexp pattern strings that are matched against all test paths, matched tests are skipped
-  // testPathIgnorePatterns: [
-  //   "/node_modules/"
-  // ],
+  // Perf harness lives under __tests__/perf and is excluded from the default
+  // run (npm test / npm run test:coverage) — see `test:perf` for running it.
+  // Kept in config rather than a CLI flag so a positional path filter (e.g.
+  // `npm test -- __tests__/services/Libs.spec.ts`) isn't swallowed as another
+  // ignore pattern by Jest's array-typed --testPathIgnorePatterns.
+  testPathIgnorePatterns: ['/node_modules/', '__tests__/perf'],
 
   // The regexp pattern Jest uses to detect test files
   // testRegex: "",

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "compile": "webpack --config webpack.config.js --color",
     "dev": "webpack --config webpack.config.js --progress --color --watch",
     "lint": "eslint -c .eslintrc.json --max-warnings 0 --ext .ts src/",
-    "test": "jest --testPathIgnorePatterns /node_modules/ __tests__.perf",
+    "test": "jest",
     "test:coverage": "jest --coverage",
-    "test:perf": "jest __tests__/perf --runInBand",
+    "test:perf": "jest --testPathIgnorePatterns=/node_modules/ --runInBand -- __tests__/perf",
     "test-all": "npm run test && npm run lint"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "compile": "webpack --config webpack.config.js --color",
     "dev": "webpack --config webpack.config.js --progress --color --watch",
     "lint": "eslint -c .eslintrc.json --max-warnings 0 --ext .ts src/",
-    "test": "jest",
+    "test": "jest --testPathIgnorePatterns /node_modules/ __tests__.perf",
     "test:coverage": "jest --coverage",
+    "test:perf": "jest __tests__/perf --runInBand",
     "test-all": "npm run test && npm run lint"
   },
   "engines": {

--- a/src/background/index.ts
+++ b/src/background/index.ts
@@ -39,6 +39,11 @@ browser.tabs.onRemoved.addListener(async (tabId, removeInfo) => {
   TabEvents.cleanFromTabEvents();
 });
 
+browser.tabs.onActivated.addListener(async (activeInfo) => {
+  await ready();
+  TabEvents.onTabActivated(activeInfo);
+});
+
 // --- Cookies ---
 
 browser.cookies.onChanged.addListener(async (changeInfo) => {

--- a/src/background/lifecycle.ts
+++ b/src/background/lifecycle.ts
@@ -65,21 +65,21 @@ export function _resetForTests(): void {
 const browserSessionStorage: any = (browser.storage as any).session;
 
 /**
- * Subscriber wrapper that invokes `fn` only when one of the selected slices
- * changes identity. Subscribing a listener to the whole store makes it react to
+ * Subscriber wrapper that invokes `fn` only when the selected slice changes
+ * identity. Subscribing a listener to the whole store makes it react to
  * every dispatch: SettingService ran its full settings diff, and a
  * checkIfProtected() costing five extension-API calls, on each cache write,
  * activity-log entry and counter bump.
  */
-function onSlicesChange(
+function onSliceChange(
   store: Store<State, ReduxAction>,
-  selects: Array<(s: State) => unknown>,
+  select: (s: State) => unknown,
   fn: () => void,
 ): () => void {
-  let prev = selects.map((select) => select(store.getState()));
+  let prev = select(store.getState());
   return () => {
-    const next = selects.map((select) => select(store.getState()));
-    if (next.every((value, i) => value === prev[i])) return;
+    const next = select(store.getState());
+    if (next === prev) return;
     prev = next;
     fn();
   };
@@ -160,12 +160,12 @@ async function init(): Promise<void> {
   StoreUser.init(store);
   SettingService.init();
   store.subscribe(
-    onSlicesChange(store, [(s) => s.settings], SettingService.onSettingsChange),
+    onSliceChange(store, (s) => s.settings, SettingService.onSettingsChange),
   );
   // The action icon reflects list membership too, and onSettingsChange no longer
   // sees list-only changes.
   store.subscribe(
-    onSlicesChange(store, [(s) => s.lists], () => {
+    onSliceChange(store, (s) => s.lists, () => {
       void checkIfProtected(store.getState());
     }),
   );

--- a/src/background/lifecycle.ts
+++ b/src/background/lifecycle.ts
@@ -64,6 +64,27 @@ export function _resetForTests(): void {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 const browserSessionStorage: any = (browser.storage as any).session;
 
+/**
+ * Subscriber wrapper that invokes `fn` only when one of the selected slices
+ * changes identity. Subscribing a listener to the whole store makes it react to
+ * every dispatch: SettingService ran its full settings diff, and a
+ * checkIfProtected() costing five extension-API calls, on each cache write,
+ * activity-log entry and counter bump.
+ */
+function onSlicesChange(
+  store: Store<State, ReduxAction>,
+  selects: Array<(s: State) => unknown>,
+  fn: () => void,
+): () => void {
+  let prev = selects.map((select) => select(store.getState()));
+  return () => {
+    const next = selects.map((select) => select(store.getState()));
+    if (next.every((value, i) => value === prev[i])) return;
+    prev = next;
+    fn();
+  };
+}
+
 async function init(): Promise<void> {
   const local = await browser.storage.local.get();
   let stateFromStorage: Partial<State> = {};
@@ -138,7 +159,16 @@ async function init(): Promise<void> {
 
   StoreUser.init(store);
   SettingService.init();
-  store.subscribe(SettingService.onSettingsChange);
+  store.subscribe(
+    onSlicesChange(store, [(s) => s.settings], SettingService.onSettingsChange),
+  );
+  // The action icon reflects list membership too, and onSettingsChange no longer
+  // sees list-only changes.
+  store.subscribe(
+    onSlicesChange(store, [(s) => s.lists], () => {
+      void checkIfProtected(store.getState());
+    }),
+  );
   store.subscribe(saveSubscriber);
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-call

--- a/src/redux/Actions.ts
+++ b/src/redux/Actions.ts
@@ -14,7 +14,6 @@
 
 import { ActionCreator, Dispatch } from 'redux';
 import { ThunkAction } from 'redux-thunk';
-import { checkIfProtected } from '../services/BrowserActionService';
 import { cleanCookiesOperation } from '../services/CleanupService';
 import {
   getContainerExpressionDefault,
@@ -100,18 +99,15 @@ export const addExpression = (payload: Expression) => (
     },
     type: ReduxConstants.ADD_EXPRESSION,
   });
-  checkIfProtected(getState());
 };
 
 export const clearExpressions = (payload: StoreIdToExpressionList) => (
   dispatch: Dispatch<ReduxAction>,
-  getState: GetState,
 ): void => {
   dispatch({
     payload,
     type: ReduxConstants.CLEAR_EXPRESSIONS,
   });
-  checkIfProtected(getState());
 };
 
 export const removeExpression = (payload: Expression) => (
@@ -126,7 +122,6 @@ export const removeExpression = (payload: Expression) => (
     },
     type: ReduxConstants.REMOVE_EXPRESSION,
   });
-  checkIfProtected(getState());
 };
 
 export const updateExpression = (payload: Expression) => (
@@ -183,18 +178,15 @@ export const updateExpression = (payload: Expression) => (
       }
     }
   }
-  checkIfProtected(getState());
 };
 
 export const removeList = (payload: keyof StoreIdToExpressionList) => (
   dispatch: Dispatch<ReduxAction>,
-  getState: GetState,
 ): void => {
   dispatch({
     payload,
     type: ReduxConstants.REMOVE_LIST,
   });
-  checkIfProtected(getState());
 };
 
 export const addActivity = (payload: ActivityLog): ADD_ACTIVITY_LOG => ({

--- a/src/services/BrowserActionService.ts
+++ b/src/services/BrowserActionService.ts
@@ -189,19 +189,29 @@ async function getGlobalIconImageData(enabled: boolean): Promise<ImageData | nul
   return loadIconData(globalIconPath(enabled));
 }
 
+async function writeIcon(
+  imageData: ImageData,
+  iconPath: string,
+  tabId?: number,
+): Promise<void> {
+  const scope = tabId === undefined ? 'global' : 'tab';
+  try {
+    await browser.action.setIcon(
+      tabId === undefined
+        ? { imageData: { 48: imageData } }
+        : { imageData: { 48: imageData }, tabId },
+    );
+  } catch (err) {
+    bacWarn(`[CAD] browser.action.setIcon (${scope}) failed for ${iconPath}`, err);
+  }
+}
+
 // Set background icon for browser.
 export const setGlobalIcon = async (enabled: boolean): Promise<void> => {
   const imageData = await getGlobalIconImageData(enabled);
   if (!imageData) return; // loadIconData already logged, or setIcon unsupported
 
-  try {
-    await browser.action.setIcon({ imageData: { 48: imageData } });
-  } catch (err) {
-    bacWarn(
-      `[CAD] browser.action.setIcon (global) failed for ${globalIconPath(enabled)}`,
-      err,
-    );
-  }
+  await writeIcon(imageData, globalIconPath(enabled));
 };
 
 // Per-tab icon overrides set by setIconColor outlive a service-worker restart,
@@ -209,20 +219,16 @@ export const setGlobalIcon = async (enabled: boolean): Promise<void> => {
 // the Active Mode toggle. Doing it on every wake would erase per-site colours
 // that the following checkIfProtected() only restores for the active tabs.
 export const resetAllTabIcons = async (enabled: boolean): Promise<void> => {
-  await setGlobalIcon(enabled);
-
   const imageData = await getGlobalIconImageData(enabled);
   if (!imageData) return; // loadIconData already logged, or setIcon unsupported
 
   const iconPath = globalIconPath(enabled);
+  await writeIcon(imageData, iconPath);
+
   const tabAwait = await browser.tabs.query({ windowType: 'normal' });
   for (const tab of tabAwait) {
     if (tab.id !== browser.tabs.TAB_ID_NONE) {
-      try {
-        await browser.action.setIcon({ imageData: { 48: imageData }, tabId: tab.id });
-      } catch (err) {
-        bacWarn(`[CAD] browser.action.setIcon (tab) failed for ${iconPath}`, err);
-      }
+      await writeIcon(imageData, iconPath, tab.id);
     }
   }
 };

--- a/src/services/BrowserActionService.ts
+++ b/src/services/BrowserActionService.ts
@@ -179,11 +179,14 @@ const setIconColor = async (
   setBadgeColor(tab, color);
 };
 
+const globalIconPath = (enabled: boolean): string =>
+  `icons/icon_48${enabled ? '' : '_greyscale'}.png`;
+
 // Set background icon for browser.
 export const setGlobalIcon = async (enabled: boolean): Promise<void> => {
   if (!browser.action.setIcon) return;
 
-  const iconPath = `icons/icon_48${enabled ? '' : '_greyscale'}.png`;
+  const iconPath = globalIconPath(enabled);
   const imageData = await loadIconData(iconPath);
   if (!imageData) return; // loadIconData already logged
 
@@ -192,6 +195,19 @@ export const setGlobalIcon = async (enabled: boolean): Promise<void> => {
   } catch (err) {
     bacWarn(`[CAD] browser.action.setIcon (global) failed for ${iconPath}`, err);
   }
+};
+
+// Per-tab icon overrides set by setIconColor outlive a service-worker restart,
+// so clearing them is only correct when the global icon changes meaning — i.e.
+// the Active Mode toggle. Doing it on every wake would erase per-site colours
+// that the following checkIfProtected() only restores for the active tabs.
+export const resetAllTabIcons = async (enabled: boolean): Promise<void> => {
+  await setGlobalIcon(enabled);
+  if (!browser.action.setIcon) return;
+
+  const iconPath = globalIconPath(enabled);
+  const imageData = await loadIconData(iconPath);
+  if (!imageData) return;
 
   const tabAwait = await browser.tabs.query({ windowType: 'normal' });
   for (const tab of tabAwait) {

--- a/src/services/BrowserActionService.ts
+++ b/src/services/BrowserActionService.ts
@@ -182,18 +182,25 @@ const setIconColor = async (
 const globalIconPath = (enabled: boolean): string =>
   `icons/icon_48${enabled ? '' : '_greyscale'}.png`;
 
+// Shared guard + load for the default (global) icon, used by both setGlobalIcon
+// and resetAllTabIcons so the feature check and path derivation live in one place.
+async function getGlobalIconImageData(enabled: boolean): Promise<ImageData | null> {
+  if (!browser.action.setIcon) return null;
+  return loadIconData(globalIconPath(enabled));
+}
+
 // Set background icon for browser.
 export const setGlobalIcon = async (enabled: boolean): Promise<void> => {
-  if (!browser.action.setIcon) return;
-
-  const iconPath = globalIconPath(enabled);
-  const imageData = await loadIconData(iconPath);
-  if (!imageData) return; // loadIconData already logged
+  const imageData = await getGlobalIconImageData(enabled);
+  if (!imageData) return; // loadIconData already logged, or setIcon unsupported
 
   try {
     await browser.action.setIcon({ imageData: { 48: imageData } });
   } catch (err) {
-    bacWarn(`[CAD] browser.action.setIcon (global) failed for ${iconPath}`, err);
+    bacWarn(
+      `[CAD] browser.action.setIcon (global) failed for ${globalIconPath(enabled)}`,
+      err,
+    );
   }
 };
 
@@ -203,12 +210,11 @@ export const setGlobalIcon = async (enabled: boolean): Promise<void> => {
 // that the following checkIfProtected() only restores for the active tabs.
 export const resetAllTabIcons = async (enabled: boolean): Promise<void> => {
   await setGlobalIcon(enabled);
-  if (!browser.action.setIcon) return;
+
+  const imageData = await getGlobalIconImageData(enabled);
+  if (!imageData) return; // loadIconData already logged, or setIcon unsupported
 
   const iconPath = globalIconPath(enabled);
-  const imageData = await loadIconData(iconPath);
-  if (!imageData) return;
-
   const tabAwait = await browser.tabs.query({ windowType: 'normal' });
   for (const tab of tabAwait) {
     if (tab.id !== browser.tabs.TAB_ID_NONE) {

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -357,11 +357,11 @@ export const getContainerExpressionDefault = (
   const getExpression = (list: string): Expression | undefined => {
     return state.lists[list]
       ? state.lists[list].find((exp) => {
-        return (
-          exp.listType === listType &&
-          exp.expression === `_Default:${listType}`
-        );
-      })
+          return (
+            exp.listType === listType &&
+            exp.expression === `_Default:${listType}`
+          );
+        })
       : undefined;
   };
   const exp: Expression = {
@@ -612,24 +612,27 @@ export const isFirefoxNotAndroid = (cache: CacheMap): boolean => {
  */
 let firstPartyIsolateProbe: Promise<boolean> | null = null;
 
-/**
- * Test for FirstPartyIsolation (Firefox).
- * Workaround for not needing Firefox 'Privacy' permission.
- */
-export const isFirstPartyIsolate = async (): Promise<boolean> => {
-  try {
-    if (!firstPartyIsolateProbe) {
-      await browser.cookies.getAll({ domain: '' });
-      firstPartyIsolateProbe = Promise.resolve(false);
-    }
-
-  } catch (e) {
-    const isFPI = (e as Error).message.indexOf('firstPartyDomain') !== -1;
-    // Inconclusive (e.g. a transient error unrelated to FPI) — don't
-    // pin a possibly-wrong `false` for the rest of the service worker's
-    // life. Clear the cache so the next call re-probes.
-    if (!isFPI) firstPartyIsolateProbe = null;
-    return isFPI;
+export const isFirstPartyIsolate = (): Promise<boolean> => {
+  if (!firstPartyIsolateProbe) {
+    firstPartyIsolateProbe = browser.cookies
+      .getAll({
+        domain: '',
+      })
+      .then(() => {
+        // No error = most likely not enabled.
+        return false;
+      })
+      .catch((e) => {
+        // Error usually if firstPartyIsolate is enabled as it requires firstPartyDomain Property.
+        const isFPI = (e as Error).message.indexOf('firstPartyDomain') !== -1;
+        if (!isFPI) {
+          // Inconclusive (e.g. a transient error unrelated to FPI) — don't
+          // pin a possibly-wrong `false` for the rest of the service worker's
+          // life. Clear the cache so the next call re-probes.
+          firstPartyIsolateProbe = null;
+        }
+        return isFPI;
+      });
   }
   return firstPartyIsolateProbe;
 };
@@ -775,7 +778,9 @@ export const prepareCookieDomain = (
 
   const sDot = cookieDomain.startsWith('.') ? 1 : 0;
 
-  return `http${cookie.secure ? 's' : ''}://${cookieDomain.slice(sDot)}${cookie.path}`;
+  return `http${cookie.secure ? 's' : ''}://${cookieDomain.slice(sDot)}${
+    cookie.path
+  }`;
 };
 
 /**
@@ -903,7 +908,9 @@ export const showNotification = (
   browser.notifications.create(sid, {
     iconUrl: browser.runtime.getURL('icons/icon_48.png'),
     message: x.msg,
-    title: `CAD ${browser.runtime.getManifest().version} - ${x.title ? x.title : browser.i18n.getMessage('manualActionNotification')}`,
+    title: `CAD ${browser.runtime.getManifest().version} - ${
+      x.title ? x.title : browser.i18n.getMessage('manualActionNotification')
+    }`,
     type: 'basic',
   });
   setTimeout(() => {

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -599,23 +599,31 @@ export const isFirefoxNotAndroid = (cache: CacheMap): boolean => {
   );
 };
 
-/**
- * Test for FirstPartyIsolation (Firefox).
- * Workaround for not needing Firefox 'Privacy' permission.
- */
-export const isFirstPartyIsolate = async (): Promise<boolean> => {
-  return browser.cookies
-    .getAll({
-      domain: '',
-    })
-    .then(() => {
-      // No error = most likely not enabled.
-      return Promise.resolve(false);
-    })
-    .catch((e) => {
-      // Error usually if firstPartyIsolate is enabled as it requires firstPartyDomain Property.
-      return Promise.resolve(e.message.indexOf('firstPartyDomain') !== -1);
-    });
+// The answer is a browser capability that cannot change while this service
+// worker lives, and the caller runs on every completed page load. Cache the
+// promise rather than the value so concurrent callers share one probe.
+let firstPartyIsolateProbe: Promise<boolean> | null = null;
+
+export const isFirstPartyIsolate = (): Promise<boolean> => {
+  if (!firstPartyIsolateProbe) {
+    firstPartyIsolateProbe = browser.cookies
+      .getAll({
+        domain: '',
+      })
+      .then(() => {
+        // No error = most likely not enabled.
+        return false;
+      })
+      .catch((e) => {
+        // Error usually if firstPartyIsolate is enabled as it requires firstPartyDomain Property.
+        return (e as Error).message.indexOf('firstPartyDomain') !== -1;
+      });
+  }
+  return firstPartyIsolateProbe;
+};
+
+export const _resetFirstPartyIsolateCache = (): void => {
+  firstPartyIsolateProbe = null;
 };
 
 /*

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -357,11 +357,11 @@ export const getContainerExpressionDefault = (
   const getExpression = (list: string): Expression | undefined => {
     return state.lists[list]
       ? state.lists[list].find((exp) => {
-          return (
-            exp.listType === listType &&
-            exp.expression === `_Default:${listType}`
-          );
-        })
+        return (
+          exp.listType === listType &&
+          exp.expression === `_Default:${listType}`
+        );
+      })
       : undefined;
   };
   const exp: Expression = {
@@ -612,27 +612,24 @@ export const isFirefoxNotAndroid = (cache: CacheMap): boolean => {
  */
 let firstPartyIsolateProbe: Promise<boolean> | null = null;
 
-export const isFirstPartyIsolate = (): Promise<boolean> => {
-  if (!firstPartyIsolateProbe) {
-    firstPartyIsolateProbe = browser.cookies
-      .getAll({
-        domain: '',
-      })
-      .then(() => {
-        // No error = most likely not enabled.
-        return false;
-      })
-      .catch((e) => {
-        // Error usually if firstPartyIsolate is enabled as it requires firstPartyDomain Property.
-        const isFPI = (e as Error).message.indexOf('firstPartyDomain') !== -1;
-        if (!isFPI) {
-          // Inconclusive (e.g. a transient error unrelated to FPI) — don't
-          // pin a possibly-wrong `false` for the rest of the service worker's
-          // life. Clear the cache so the next call re-probes.
-          firstPartyIsolateProbe = null;
-        }
-        return isFPI;
-      });
+/**
+ * Test for FirstPartyIsolation (Firefox).
+ * Workaround for not needing Firefox 'Privacy' permission.
+ */
+export const isFirstPartyIsolate = async (): Promise<boolean> => {
+  try {
+    if (!firstPartyIsolateProbe) {
+      await browser.cookies.getAll({ domain: '' });
+      firstPartyIsolateProbe = Promise.resolve(false);
+    }
+
+  } catch (e) {
+    const isFPI = (e as Error).message.indexOf('firstPartyDomain') !== -1;
+    // Inconclusive (e.g. a transient error unrelated to FPI) — don't
+    // pin a possibly-wrong `false` for the rest of the service worker's
+    // life. Clear the cache so the next call re-probes.
+    if (!isFPI) firstPartyIsolateProbe = null;
+    return isFPI;
   }
   return firstPartyIsolateProbe;
 };
@@ -778,9 +775,7 @@ export const prepareCookieDomain = (
 
   const sDot = cookieDomain.startsWith('.') ? 1 : 0;
 
-  return `http${cookie.secure ? 's' : ''}://${cookieDomain.slice(sDot)}${
-    cookie.path
-  }`;
+  return `http${cookie.secure ? 's' : ''}://${cookieDomain.slice(sDot)}${cookie.path}`;
 };
 
 /**
@@ -908,9 +903,7 @@ export const showNotification = (
   browser.notifications.create(sid, {
     iconUrl: browser.runtime.getURL('icons/icon_48.png'),
     message: x.msg,
-    title: `CAD ${browser.runtime.getManifest().version} - ${
-      x.title ? x.title : browser.i18n.getMessage('manualActionNotification')
-    }`,
+    title: `CAD ${browser.runtime.getManifest().version} - ${x.title ? x.title : browser.i18n.getMessage('manualActionNotification')}`,
     type: 'basic',
   });
   setTimeout(() => {

--- a/src/services/Libs.ts
+++ b/src/services/Libs.ts
@@ -599,9 +599,17 @@ export const isFirefoxNotAndroid = (cache: CacheMap): boolean => {
   );
 };
 
-// The answer is a browser capability that cannot change while this service
-// worker lives, and the caller runs on every completed page load. Cache the
-// promise rather than the value so concurrent callers share one probe.
+/**
+ * Test for FirstPartyIsolation (Firefox). Workaround for not needing Firefox
+ * 'Privacy' permission.
+ *
+ * `privacy.firstparty.isolate` is a live about:config pref a user can flip
+ * without restarting, so this isn't truly immutable — but nobody flips it
+ * mid-session, and a cold SW wake re-probes and self-corrects either way.
+ * The caller runs on every completed page load, so cache the promise rather
+ * than the value, both to avoid re-probing every call and so concurrent
+ * callers share one in-flight probe.
+ */
 let firstPartyIsolateProbe: Promise<boolean> | null = null;
 
 export const isFirstPartyIsolate = (): Promise<boolean> => {
@@ -616,7 +624,14 @@ export const isFirstPartyIsolate = (): Promise<boolean> => {
       })
       .catch((e) => {
         // Error usually if firstPartyIsolate is enabled as it requires firstPartyDomain Property.
-        return (e as Error).message.indexOf('firstPartyDomain') !== -1;
+        const isFPI = (e as Error).message.indexOf('firstPartyDomain') !== -1;
+        if (!isFPI) {
+          // Inconclusive (e.g. a transient error unrelated to FPI) — don't
+          // pin a possibly-wrong `false` for the rest of the service worker's
+          // life. Clear the cache so the next call re-probes.
+          firstPartyIsolateProbe = null;
+        }
+        return isFPI;
       });
   }
   return firstPartyIsolateProbe;

--- a/src/services/SettingService.ts
+++ b/src/services/SettingService.ts
@@ -16,7 +16,7 @@ import StoreUser from './StoreUser';
 import ContextualIdentitiesEvents from './ContextualIdentitiesEvents';
 import { validateSettings } from '../redux/Actions';
 import { cadLog, siteDataToBrowser, SITEDATATYPES } from './Libs';
-import { checkIfProtected, setGlobalIcon } from './BrowserActionService';
+import { checkIfProtected, resetAllTabIcons } from './BrowserActionService';
 import ContextMenuEvents from './ContextMenuEvents';
 import { ReduxConstants } from '../typings/ReduxConstants';
 
@@ -90,7 +90,7 @@ export default class SettingService extends StoreUser {
       if (!active) {
         await browser.alarms.clear('activeModeAlarm');
       }
-      await setGlobalIcon(active);
+      await resetAllTabIcons(active);
       ContextMenuEvents.updateMenuItemCheckbox(
         ContextMenuEvents.MenuID.ACTIVE_MODE,
         active,

--- a/src/services/TabEvents.ts
+++ b/src/services/TabEvents.ts
@@ -344,6 +344,34 @@ export default class TabEvents extends StoreUser {
       showNumberOfCookiesInIcon(tab, cookieLength);
     }
   };
+  // Switching to a tab is the only moment a stale per-tab icon becomes visible:
+  // list edits repaint just the active tab, so a tab that was in the background
+  // when its list membership changed still shows the old colour.
+  public static onTabActivated = async (activeInfo: {
+    tabId: number;
+    windowId: number;
+  }): Promise<void> => {
+    const debug = getSetting(
+      StoreUser.store.getState(),
+      SettingID.DEBUG_MODE,
+    ) as boolean;
+    let tab: browser.tabs.Tab;
+    try {
+      tab = await browser.tabs.get(activeInfo.tabId);
+    } catch (err) {
+      cadLog(
+        {
+          msg: 'TabEvents.onTabActivated: tab no longer exists.',
+          type: 'warn',
+          x: { activeInfo, err: `${err as Error}` },
+        },
+        debug,
+      );
+      return;
+    }
+    await checkIfProtected(StoreUser.store.getState(), tab);
+  };
+
   // Add a delay to prevent multiple spawns of the browsingDataCleanup cookie
   protected static onTabUpdateDelay = false;
 

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -1,6 +1,14 @@
 {
   "releases": [
     {
+      "version": "1.3.1",
+      "notes": [
+        "Fixed the toolbar icon losing its per-site colour on background tabs after the extension's background worker restarted.",
+        "The extension now does less work when your browser starts with many tabs open.",
+        "Removed repeated internal checks that ran on every page load and on unrelated internal updates."
+      ]
+    },
+    {
       "version": "1.3.0",
       "notes": [
         "Redesigned interface — the popup and settings pages are rebuilt on a single design system, with a lighter sidebar, restyled buttons, tables and dropdowns, and consistent spacing throughout.",

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -5,7 +5,8 @@
       "notes": [
         "Fixed the toolbar icon losing its per-site colour on background tabs after the extension's background worker restarted.",
         "The extension now does less work when your browser starts with many tabs open.",
-        "Removed repeated internal checks that ran on every page load and on unrelated internal updates."
+        "Removed repeated internal checks that ran on every page load and on unrelated internal updates.",
+        "The toolbar icon now updates as soon as you switch to a tab, so a site you added to a list while its tab sat in the background no longer shows the old colour."
       ]
     },
     {

--- a/tools/perf/README.md
+++ b/tools/perf/README.md
@@ -1,0 +1,103 @@
+# Background hot-path measurement
+
+Tooling used to decide whether CAD's MV3 background work is worth optimising, and
+to verify the effect of any change. Everything here is measurement only — it is
+not shipped in the extension bundle.
+
+## The three measurements
+
+| # | What | How | Deterministic? |
+|---|------|-----|----------------|
+| 1 | **Extension-API calls per event** | `__tests__/perf/hotpaths.test.ts` runs the real CAD code (`lifecycle.init`, `TabEvents`, `CookieEvents`, `SettingService`) against `instrumentedBrowser.js`, counting every `browser.*` call | **Yes** — same code, same counts |
+| 2 | **Per-API IPC latency + background event rates** | `browser-meter/` extension in a real Chromium, reporting to `collector.js` | No — environment dependent |
+| 3 | **CAD service-worker residency + JS heap** | `cad-sw-probe.js` drives Chromium over CDP with the real CAD extension loaded | Partly |
+
+## Comparing a change against the baseline
+
+**Measurement 1 is the honest A/B signal.** API call counts come from the code
+alone, so a before/after diff is exact and reproducible.
+
+**Measurement 2's event rates are an environmental input, not a result.** How many
+`cookies.onChanged` events fire per page load depends on what the sites served
+that day, not on CAD. Do not read a change in that number as an effect of your
+patch. The fair comparison holds the baseline rates fixed and applies the *new*
+call counts to them — which is what `report.js` does.
+
+Per-API latency (also from measurement 2) is fairly stable on the same machine,
+but re-measure it if the comparison is close.
+
+## Running it
+
+### 1. Call counts (fast, no browser)
+
+```bash
+npm run test:perf
+```
+
+This harness prints measurements rather than asserting behaviour, so `npm test`
+excludes it and it gets its own script.
+
+### 2. IPC latency + event rates
+
+Chrome 137+ refuses `--load-extension`, so use Playwright's Chromium:
+
+```
+%LOCALAPPDATA%\ms-playwright\chromium-<rev>\chrome-win64\chrome.exe
+```
+
+```bash
+node tools/perf/collector.js tools/perf/runs/after     # terminal 1, listens on :8777
+```
+
+```powershell
+& $chromium --user-data-dir=<fresh-temp-dir> `
+            --load-extension=tools\perf\browser-meter `
+            --disable-extensions-except=tools\perf\browser-meter `
+            --no-first-run --no-default-browser-check `
+            --disable-backgrounding-occluded-windows about:blank
+```
+
+The extension drives itself: IPC benchmark, then 10 fixed sites at 8 s each, then
+60 s idle. It writes `measured.json` and the collector exits.
+
+### 3. CAD service-worker residency + heap
+
+```powershell
+& $chromium --user-data-dir=<fresh-temp-dir> `
+            --load-extension=extension --disable-extensions-except=extension `
+            --remote-debugging-port=9222 `
+            --no-first-run --no-default-browser-check `
+            --disable-backgrounding-occluded-windows about:blank
+```
+
+```bash
+node tools/perf/cad-sw-probe.js tools/perf/runs/after
+```
+
+Phases: 75 s quiet, 10 sites at 8 s, 120 s idle, then one heap read.
+
+Liveness is tracked with CDP target **discovery only**. Never attach a debugger to
+the service worker while measuring lifetime — attaching suppresses Chrome's idle
+termination and the SW will appear to live forever. The single attach at the end
+is only for `Runtime.getHeapUsage`.
+
+### 4. Report
+
+```bash
+node tools/perf/report.js                        # baseline
+node tools/perf/report.js tools/perf/runs/after  # a new run
+```
+
+## Keeping runs comparable
+
+- Do not edit the site list in `browser-meter/sw.js` or `cad-sw-probe.js`.
+- Always use a **fresh** `--user-data-dir`; a warm cookie jar changes event counts.
+- Use the same Chromium revision.
+- `report.js` uses **mean** latency, not p50: `performance.now()` in a service
+  worker is coarsened to 100 us, so p50 collapses to 0.100 for nearly every API
+  and understates the cost.
+
+## Baseline
+
+`baseline/` holds the pre-change run. See `baseline/RESULTS.md` for the summary
+and the conclusions drawn from it.

--- a/tools/perf/README.md
+++ b/tools/perf/README.md
@@ -17,6 +17,13 @@ not shipped in the extension bundle.
 **Measurement 1 is the honest A/B signal.** API call counts come from the code
 alone, so a before/after diff is exact and reproducible.
 
+`report.js`'s `COUNTS` constant is a hand-maintained model of the code at
+branch base (currently `d43ee51`) — it is not re-derived per change, so its
+API-call-derived output (per-event cost, cold-init totals, "what each option
+saves") only reflects that pre-change code; `report.js` warns when pointed at
+a data directory other than `baseline/` for this reason. For authoritative
+post-change call counts, read `npm run test:perf`'s output directly.
+
 **Measurement 2's event rates are an environmental input, not a result.** How many
 `cookies.onChanged` events fire per page load depends on what the sites served
 that day, not on CAD. Do not read a change in that number as an effect of your

--- a/tools/perf/baseline/RESULTS.md
+++ b/tools/perf/baseline/RESULTS.md
@@ -57,7 +57,12 @@ Breakdowns:
   `action.getTitle/setTitle/setIcon/setBadgeBackgroundColor/setBadgeText/setBadgeTextColor`
 - redux dispatch -> `tabs.query`, `action.getTitle/setTitle/setIcon/setBadgeBackgroundColor`
 - cold init -> `action.setIcon` x(2+N), `tabs.query` x2, `storage.local.get`,
-  `storage.session.get` x2, FPI probe, `action.getTitle/setTitle/setBadgeBackgroundColor`
+  `storage.session.get` x2, the CHIPS probe, `action.getTitle/setTitle/setBadgeBackgroundColor`
+
+The single `cookies.getAll` during cold init is `detectPartitionedCookieSupport`
+(CHIPS) at `lifecycle.ts:129` — **not** the first-party-isolation probe. The cost
+model prices it with the FPI probe's measured latency because both are one
+`cookies.getAll` (0.150 vs 0.146 ms); only the label was wrong.
 
 ## Real CAD service worker
 

--- a/tools/perf/baseline/RESULTS.md
+++ b/tools/perf/baseline/RESULTS.md
@@ -127,9 +127,11 @@ debounce ceiling of 1 per 750 ms sustained.
 
 Measured against commits `d83bb4e..6d1cacb` (icon split, slice-scoped
 subscriptions, memoised FPI probe), same machine, same Chromium revision
-(`chromium-1232`). Raw data: `tools/perf/runs/after/measured.json`,
-`tools/perf/runs/after/cad-sw.json`. `npm run test:perf` output captured
-separately (see Task 4 report).
+(`chromium-1232`). Raw data: `tools/perf/baseline/after-round-1/measured.json`,
+`tools/perf/baseline/after-round-1/cad-sw.json` (copied here because
+`tools/perf/runs/` is gitignored — ad-hoc run data isn't tracked, only
+`baseline/`). `npm run test:perf` output captured separately (see Task 4
+report).
 
 ### M1 — cold init, `npm run test:perf` (deterministic, the real signal)
 

--- a/tools/perf/baseline/RESULTS.md
+++ b/tools/perf/baseline/RESULTS.md
@@ -1,0 +1,119 @@
+# Baseline — before any hot-path changes
+
+Recorded 2026-08-06 against `d43ee51` (CAD 1.3.0), Chromium 1232, Windows 11.
+Raw data: `measured.json`, `cad-sw.json`. Regenerate the summary with
+`node tools/perf/report.js`.
+
+## Measured inputs
+
+**Real browsing — 10 page loads in 82 s**
+
+| | |
+|---|---|
+| `cookies.onChanged` | 2124 events = **212 per page load** |
+| causes | explicit 1147, overwrite 686, expired_overwrite 291 |
+| removals | 977 |
+| `tabs.onUpdated` | 69 events = 6.9 per page load (28 with `status:complete`) |
+
+**Idle — 60 s, 11 tabs open, no interaction**
+
+| | |
+|---|---|
+| `cookies.onChanged` | 50 events = 2977/hour |
+| `tabs.onUpdated` | 0 |
+
+**Per-API latency (mean ms, real Chromium)**
+
+| API | mean |
+|---|---|
+| `action.setIcon(imageData)` | **0.538** |
+| `storage.local.set(5KB)` | 0.187 |
+| `tabs.query({active:true})` | 0.152 |
+| `cookies.getAll({domain:''})` (FPI probe) | 0.150 |
+| `cookies.getAll({domain})` | 0.146 |
+| `action.setTitle()` | 0.134 |
+| `action.setBadgeText()` | 0.137 |
+| `action.setBadgeBackgroundColor()` | 0.125 |
+| `storage.local.get()` | 0.097 |
+| `action.getTitle()` | 0.088 |
+| `storage.session.get()` | 0.078 |
+| `alarms.get()` | 0.071 |
+
+`action.setIcon` is 3.5x more expensive than anything else CAD calls.
+
+## API calls per event (deterministic — the A/B signal)
+
+| Event | API calls | Cost |
+|---|---|---|
+| `cookies.onChanged` | **1** (`tabs.query`) | 0.185 ms |
+| `getAllCookieActions` | **8** | 1.569 ms |
+| one redux dispatch | **5** | 1.171 ms |
+| cold SW init, N tabs | **10 + N** | 3.23 ms @1 tab -> 34.95 ms @60 tabs |
+
+Breakdowns:
+
+- `cookies.onChanged` -> `tabs.query({active:true})`
+- `getAllCookieActions` -> `cookies.getAll` x2 (one is the FPI probe),
+  `action.getTitle/setTitle/setIcon/setBadgeBackgroundColor/setBadgeText/setBadgeTextColor`
+- redux dispatch -> `tabs.query`, `action.getTitle/setTitle/setIcon/setBadgeBackgroundColor`
+- cold init -> `action.setIcon` x(2+N), `tabs.query` x2, `storage.local.get`,
+  `storage.session.get` x2, FPI probe, `action.getTitle/setTitle/setBadgeBackgroundColor`
+
+## Real CAD service worker
+
+| | |
+|---|---|
+| observed | 278 s |
+| resident | 227 s = **81.6%** |
+| cold starts | **2** |
+| JS heap | **3.48 MB used / 4.50 MB allocated** |
+
+| phase | window | SW alive | cold starts |
+|---|---|---|---|
+| quiet (no tabs) | 75 s | 31.9% | 0 |
+| browsing | 80 s | 99.8% | 1 |
+| idle, 11 tabs open | 120 s | **100%** | **0** |
+
+**The service worker never sleeps while tabs are open.** The ~0.8 events/s cookie
+stream keeps resetting Chrome's 30 s idle timer, so MV3's termination model never
+engages. It only sleeps with no tabs open (terminated after 23.9 s in the quiet
+phase).
+
+## Derived cost
+
+| Scenario | CPU/hour | % of one core |
+|---|---|---|
+| sustained heavy browsing | 17.9 – 24.8 s | 0.50 – 0.69 % |
+| idle, tabs open | 0.55 s | 0.015 % |
+| mixed day (20% browse / 80% idle) | 4.0 – 5.4 s | 0.11 – 0.15 % |
+
+Energy at ~3 J per CPU-second on a 60 Wh battery: **0.056 – 0.075 % of one full
+charge over a 10-hour mixed day.**
+
+The range on `getAllCookieActions` is min = once per page load, max = the
+debounce ceiling of 1 per 750 ms sustained.
+
+## Conclusions
+
+1. **The dominant cost is `cookies.onChanged` -> `tabs.query`**, unconditionally,
+   212 times per page load: 17.24 of the 17.93 s/h floor under heavy browsing
+   (**96%**). `CookieEvents.ts:28` does this before any cheap filtering.
+2. **`SettingService.onSettingsChange` runs on every store dispatch**, not just on
+   settings changes (`lifecycle.ts:141`), ending in `checkIfProtected()` —
+   5 IPC calls including the expensive `setIcon`.
+3. **`isFirstPartyIsolate()` probes on every `getAllCookiesForDomain`**
+   (`Libs.ts:227`); on Chrome the answer is always `false` and is cacheable.
+4. **`setGlobalIcon`'s O(tabs) loop is low priority.** It is paid only on cold
+   init, and cold starts are rare — 2 in 278 s, zero during idle-with-tabs. It
+   matters at browser startup, not in steady state.
+5. **Absolute cost is tiny.** Even eliminating all background work saves under
+   0.1% of a battery charge per day. Any change here should be justified as code
+   quality or correctness, not as a battery feature.
+
+## Wrong hypotheses this run killed
+
+- *"Idle is the worst case because sparse events force repeated cold inits."*
+  Backwards. Idle-with-tabs keeps the SW **100%** resident with **zero** cold
+  starts; the cold-init path is nearly free in steady state.
+- *"Cold init costs 30–80 ms of CPU."* The JS is ~0.6 ms; the cost is IPC
+  round-trips and it scales with open tab count (3.2 ms @1 tab, 35 ms @60).

--- a/tools/perf/baseline/RESULTS.md
+++ b/tools/perf/baseline/RESULTS.md
@@ -122,3 +122,118 @@ debounce ceiling of 1 per 750 ms sustained.
   starts; the cold-init path is nearly free in steady state.
 - *"Cold init costs 30–80 ms of CPU."* The JS is ~0.6 ms; the cost is IPC
   round-trips and it scales with open tab count (3.2 ms @1 tab, 35 ms @60).
+
+## After round 1 — Tasks 1-3 applied (2026-08-06)
+
+Measured against commits `d83bb4e..6d1cacb` (icon split, slice-scoped
+subscriptions, memoised FPI probe), same machine, same Chromium revision
+(`chromium-1232`). Raw data: `tools/perf/runs/after/measured.json`,
+`tools/perf/runs/after/cad-sw.json`. `npm run test:perf` output captured
+separately (see Task 4 report).
+
+### M1 — cold init, `npm run test:perf` (deterministic, the real signal)
+
+`perf.totalCalls()` is now **flat at 19 calls regardless of open-tab count** —
+confirmed at 1, 10, 30 and 60 tabs. Before this branch (re-measured against
+`b6bde72` with the identical, unmodified harness, for a true apples-to-apples
+diff) it scaled with tab count: 21 → 30 → 50 → 80 calls for 1 → 10 → 30 → 60
+tabs (~+1 API call per open tab, from the O(tabs) `action.setIcon` loop that
+`d83bb4e`/`b5a4ad0` removed from the init path).
+
+The absolute numbers (19 / 21) don't match this document's earlier "12" /
+"10 expected" framing verbatim: that framing counted only `browser.action.*`,
+`browser.tabs.*`, `browser.storage.*` and `browser.cookies.*` calls, excluding
+`runtime.getURL`, `runtime.getManifest`, `runtime.getPlatformInfo`, and the
+icon-loading pipeline's `fetch`/`createImageBitmap` calls (9 calls at every
+tab count, both before and after — `instrumentedBrowser.js` counts all of
+these under `perf.totalCalls()`, this document's earlier hand rollup did not).
+Subtracting that constant 9-call gap from both sides reproduces the original
+12 → 10 figures exactly. Either way the qualitative result is unchanged and is
+the one that matters: **no scaling with tab count**, confirmed on raw numbers
+alone with no reconciliation needed.
+
+### M3 — `getAllCookieActions` x200 (FPI probe caching)
+
+Before (re-measured, same harness): `cookies.getAll×400` (2 per call — one
+real lookup, one unmemoised FPI probe). After: `cookies.getAll×200` — the FPI
+probe now fires once per service-worker lifetime (`f2f8572`/`6d1cacb`), and in
+this harness that one probe call lands inside the test's own 30-call warm-up
+window, before the measured 200-call window starts, so the measured window
+pays it zero times rather than the predicted once (i.e. the cache is even more
+effective in steady state than the "201" estimate assumed).
+
+### M4 — store dispatch (informational, not part of the pass/fail gate)
+
+`npm run test:perf` fails one assertion:
+`__tests__/perf/hotpaths.test.ts:297` expects
+`perf.totalCalls() > 0` for an `ADD_CACHE` dispatch and now observes `0`. This
+is Task 2 working as designed — `lifecycle.ts`'s `onSlicesChange()` filters by
+slice-reference-equality inside the subscriber itself, so it correctly ignores
+an unrelated-slice dispatch even when the caller holds a direct `getStore()`
+reference (the opposite of what was predicted going into this round). Proof:
+`__tests__/background/lifecycle.spec.ts`'s `'does not run
+SettingService.onSettingsChange for an unrelated slice'` test, which passes.
+The stale assertion doesn't affect `npm test`/`npm run test-all`
+(`__tests__/perf` is excluded from both).
+
+### Real browser — IPC/event rates (`browser-meter`, environmental, not evidence)
+
+| | Baseline | After |
+|---|---|---|
+| `cookies.onChanged` per page load | 212 | 215 |
+| Idle `cookies.onChanged`/hour | 2977 | 1848 |
+| `action.setIcon(imageData)` mean | 0.538 ms | 0.516 ms |
+
+Day-to-day noise in what the 10 fixed sites happened to serve, not a measured
+effect of this branch — call counts (M1/M3 above) are the only deterministic
+signal.
+
+### Real browser — CAD service-worker residency (`cad-sw-probe.js`)
+
+| | Baseline | After |
+|---|---|---|
+| observed window | 278 s | 278 s |
+| SW resident | 227 s (81.6%) | 225 s (80.8%) |
+| cold starts | 2 | 2 |
+| JS heap used / allocated | 3.48 / 4.50 MB | 3.56 / 4.75 MB |
+
+Statistically indistinguishable from baseline, as predicted: cold starts are
+rare (2 in 278 s either way) and the SW stays resident while tabs are open
+regardless of the icon-loop fix, so this measurement was never expected to
+move. `tools/perf/report.js`'s derived "Option C" savings and its `COUNTS`
+table are unaffected by this round for a mechanical reason worth flagging:
+`COUNTS` in `report.js` is a hand-maintained constant (`action.setIcon`:
+`2 + tabs`, an unconditional FPI-probe count of 1 per call) that predates this
+branch and was not updated alongside Tasks 1-3, so `node tools/perf/report.js
+tools/perf/runs/after` prints the same derived cold-init/getAllCookieActions
+figures as the baseline run regardless of code changes. `npm run test:perf`
+(M1/M3 above) is the only place the actual effect of this branch shows up.
+
+### Manual real-browser check (Step 5)
+
+Confirmed by direct visual inspection (OS-level screenshots of the real
+toolbar icon, not just DOM state):
+
+- Whitelisted tab shows the default (blue) icon; unlisted tab shows red —
+  visually distinct and correct.
+- Forcing a real SW restart (`chrome://serviceworker-internals` → Stop) while
+  a whitelisted tab sat in the background: its icon was still blue after the
+  restart, with no reload — the Task 1 bug is fixed.
+- Active Mode toggle off/on (via the popup, same tab kept foregrounded
+  throughout): icon cleared to greyscale on off, returned to blue on on.
+- Closing the browser entirely and relaunching on the same profile (tabs
+  restored, new tab IDs as expected): no tab showed an *incorrect* leftover
+  color. However, one restored tab (an unlisted site) sat on the default/blue
+  icon for over a minute after its page had fully loaded, instead of updating
+  to red — traced to `TabEvents.onTabUpdate`'s single, non-per-tab debounce
+  flag (`src/services/TabEvents.ts:85-119`): when several tabs' `complete`
+  events land inside the same 750 ms window (as session restore does), only
+  the first is processed and the rest are dropped outright, not queued. An
+  isolated reload of the same tab immediately produced the correct red icon,
+  confirming the per-tab colour logic itself is correct and this is a
+  scheduling gap, not a wrong-color bug. `TabEvents.ts` is untouched by any of
+  this branch's three commits (confirmed by diffing against the pre-Task-1
+  commit), so this is a pre-existing characteristic, present identically
+  before and after this branch, not something removing the init-time loop
+  caused. Worth a human's attention as a possible follow-up, separate from
+  this branch.

--- a/tools/perf/baseline/after-round-1/cad-sw.json
+++ b/tools/perf/baseline/after-round-1/cad-sw.json
@@ -1,0 +1,148 @@
+{
+  "swUrl": "chrome-extension://cmfgjefoegphaipemehofephdofmbdbd/bundles/background.js",
+  "totalMs": 278332,
+  "aliveMs": 224966,
+  "pctAlive": 80.8,
+  "coldStarts": 2,
+  "spans": [
+    {
+      "start": 1785980498419,
+      "end": 1785980520277,
+      "ms": 21858
+    },
+    {
+      "start": 1785980573644,
+      "end": 1785980776752,
+      "ms": 203108,
+      "stillAlive": true
+    }
+  ],
+  "phaseWindows": {
+    "A-quiet": {
+      "windowMs": 75015,
+      "swAliveMs": 21857,
+      "pctAlive": 29.1,
+      "coldStarts": 0
+    },
+    "B-browse": {
+      "windowMs": 80282,
+      "swAliveMs": 80073,
+      "pctAlive": 99.7,
+      "coldStarts": 1
+    },
+    "C-idle": {
+      "windowMs": 120011,
+      "swAliveMs": 120011,
+      "pctAlive": 100,
+      "coldStarts": 0
+    },
+    "D-heap": {
+      "windowMs": 3023,
+      "swAliveMs": 3023,
+      "pctAlive": 100,
+      "coldStarts": 0
+    }
+  },
+  "heap": {
+    "usedSize": 3727984,
+    "totalSize": 4980736,
+    "embedderHeapUsedSize": 1020128,
+    "backingStorageSize": 188652
+  },
+  "log": [
+    {
+      "t": 1785980498419,
+      "ev": "SW_START",
+      "url": "chrome-extension://cmfgjefoegphaipemehofephdofmbdbd/bundles/"
+    },
+    {
+      "t": 1785980498420,
+      "ev": "PHASE",
+      "phase": "A-quiet",
+      "seconds": 75
+    },
+    {
+      "t": 1785980520277,
+      "ev": "SW_STOP",
+      "aliveMs": 21858
+    },
+    {
+      "t": 1785980573435,
+      "ev": "PHASE",
+      "phase": "B-browse",
+      "sites": 10
+    },
+    {
+      "t": 1785980573456,
+      "ev": "PAGE",
+      "url": "https://en.wikipedia.org/wiki/HTTP_cookie"
+    },
+    {
+      "t": 1785980573644,
+      "ev": "SW_START",
+      "url": "chrome-extension://cmfgjefoegphaipemehofephdofmbdbd/bundles/"
+    },
+    {
+      "t": 1785980581479,
+      "ev": "PAGE",
+      "url": "https://www.bbc.com/news"
+    },
+    {
+      "t": 1785980589499,
+      "ev": "PAGE",
+      "url": "https://stackoverflow.com/questions"
+    },
+    {
+      "t": 1785980597528,
+      "ev": "PAGE",
+      "url": "https://github.com/explore"
+    },
+    {
+      "t": 1785980605563,
+      "ev": "PAGE",
+      "url": "https://www.reddit.com/r/programming/"
+    },
+    {
+      "t": 1785980613599,
+      "ev": "PAGE",
+      "url": "https://www.imdb.com/chart/top/"
+    },
+    {
+      "t": 1785980621623,
+      "ev": "PAGE",
+      "url": "https://www.ebay.com/"
+    },
+    {
+      "t": 1785980629656,
+      "ev": "PAGE",
+      "url": "https://weather.com/"
+    },
+    {
+      "t": 1785980637685,
+      "ev": "PAGE",
+      "url": "https://www.cnn.com/"
+    },
+    {
+      "t": 1785980645712,
+      "ev": "PAGE",
+      "url": "https://www.amazon.com/"
+    },
+    {
+      "t": 1785980653717,
+      "ev": "PHASE",
+      "phase": "C-idle",
+      "seconds": 120
+    },
+    {
+      "t": 1785980773728,
+      "ev": "PHASE",
+      "phase": "D-heap"
+    },
+    {
+      "t": 1785980776751,
+      "ev": "HEAP",
+      "usedMB": 3.56,
+      "totalMB": 4.75
+    }
+  ]
+}

--- a/tools/perf/baseline/after-round-1/measured.json
+++ b/tools/perf/baseline/after-round-1/measured.json
@@ -1,0 +1,275 @@
+{
+  "startedAt": 1785980314301,
+  "phases": [
+    {
+      "kind": "phase",
+      "phase": "start",
+      "ts": 1785980319849
+    },
+    {
+      "kind": "phase",
+      "phase": "browse-start",
+      "ts": 1785980320757
+    },
+    {
+      "kind": "phase",
+      "phase": "browse-end",
+      "ts": 1785980402637
+    },
+    {
+      "kind": "phase",
+      "phase": "idle-start",
+      "ts": 1785980402638,
+      "openTabs": 11
+    },
+    {
+      "kind": "phase",
+      "phase": "idle-end",
+      "ts": 1785980463038
+    }
+  ],
+  "ipc": [
+    {
+      "name": "tabs.query({active:true})",
+      "n": 300,
+      "mean": 0.11200000007947286,
+      "p50": 0.10000002384185791,
+      "p90": 0.19999998807907104,
+      "p99": 0.30000001192092896
+    },
+    {
+      "name": "tabs.query({windowType:normal})",
+      "n": 300,
+      "mean": 0.09066666642824808,
+      "p50": 0.10000002384185791,
+      "p90": 0.19999998807907104,
+      "p99": 0.20000004768371582
+    },
+    {
+      "name": "cookies.getAll({domain})",
+      "n": 300,
+      "mean": 0.10700000007947286,
+      "p50": 0.10000002384185791,
+      "p90": 0.19999998807907104,
+      "p99": 0.30000001192092896
+    },
+    {
+      "name": "cookies.getAll({domain:\"\"}) [FPI probe]",
+      "n": 300,
+      "mean": 0.12399999996026358,
+      "p50": 0.10000002384185791,
+      "p90": 0.19999998807907104,
+      "p99": 0.30000001192092896
+    },
+    {
+      "name": "action.setIcon(imageData)",
+      "n": 300,
+      "mean": 0.5163333334525426,
+      "p50": 0.5,
+      "p90": 0.699999988079071,
+      "p99": 0.800000011920929
+    },
+    {
+      "name": "action.getTitle()",
+      "n": 300,
+      "mean": 0.08466666658719381,
+      "p50": 0.09999996423721313,
+      "p90": 0.19999998807907104,
+      "p99": 0.20000004768371582
+    },
+    {
+      "name": "action.setTitle()",
+      "n": 300,
+      "mean": 0.12866666654745737,
+      "p50": 0.10000002384185791,
+      "p90": 0.19999998807907104,
+      "p99": 0.30000001192092896
+    },
+    {
+      "name": "action.setBadgeText()",
+      "n": 300,
+      "mean": 0.13033333361148836,
+      "p50": 0.10000002384185791,
+      "p90": 0.20000004768371582,
+      "p99": 0.30000001192092896
+    },
+    {
+      "name": "action.setBadgeBackgroundColor()",
+      "n": 300,
+      "mean": 0.13899999996026358,
+      "p50": 0.10000002384185791,
+      "p90": 0.19999998807907104,
+      "p99": 0.30000001192092896
+    },
+    {
+      "name": "storage.local.get()",
+      "n": 300,
+      "mean": 0.1126666667064031,
+      "p50": 0.10000002384185791,
+      "p90": 0.19999998807907104,
+      "p99": 0.20000004768371582
+    },
+    {
+      "name": "storage.local.set(5KB)",
+      "n": 150,
+      "mean": 0.17,
+      "p50": 0.19999998807907104,
+      "p90": 0.20000004768371582,
+      "p99": 0.3999999761581421
+    },
+    {
+      "name": "storage.session.get()",
+      "n": 300,
+      "mean": 0.08933333317438762,
+      "p50": 0.10000002384185791,
+      "p90": 0.19999998807907104,
+      "p99": 0.20000004768371582
+    },
+    {
+      "name": "alarms.get()",
+      "n": 300,
+      "mean": 0.060333333412806195,
+      "p50": 0.09999996423721313,
+      "p90": 0.10000002384185791,
+      "p99": 0.19999998807907104
+    }
+  ],
+  "ipcLoaded": {
+    "tabCount": 11,
+    "results": [
+      {
+        "name": "tabs.query({windowType:normal}) @manyTabs",
+        "n": 200,
+        "mean": 0.3560000002384186,
+        "p50": 0.3999999761581421,
+        "p90": 0.40000003576278687,
+        "p99": 0.5
+      },
+      {
+        "name": "action.setIcon(imageData) @manyTabs",
+        "n": 200,
+        "mean": 0.5820000001788139,
+        "p50": 0.5999999642372131,
+        "p90": 0.800000011920929,
+        "p99": 0.9000000357627869
+      }
+    ]
+  },
+  "pages": [
+    {
+      "kind": "page",
+      "url": "https://en.wikipedia.org/wiki/HTTP_cookie",
+      "ms": 8021,
+      "openTabs": 2
+    },
+    {
+      "kind": "page",
+      "url": "https://www.bbc.com/news",
+      "ms": 8035,
+      "openTabs": 3
+    },
+    {
+      "kind": "page",
+      "url": "https://stackoverflow.com/questions",
+      "ms": 8026,
+      "openTabs": 4
+    },
+    {
+      "kind": "page",
+      "url": "https://github.com/explore",
+      "ms": 8033,
+      "openTabs": 5
+    },
+    {
+      "kind": "page",
+      "url": "https://www.reddit.com/r/programming/",
+      "ms": 8029,
+      "openTabs": 6
+    },
+    {
+      "kind": "page",
+      "url": "https://www.imdb.com/chart/top/",
+      "ms": 8025,
+      "openTabs": 7
+    },
+    {
+      "kind": "page",
+      "url": "https://www.ebay.com/",
+      "ms": 8029,
+      "openTabs": 8
+    },
+    {
+      "kind": "page",
+      "url": "https://weather.com/",
+      "ms": 8022,
+      "openTabs": 9
+    },
+    {
+      "kind": "page",
+      "url": "https://www.cnn.com/",
+      "ms": 8031,
+      "openTabs": 10
+    },
+    {
+      "kind": "page",
+      "url": "https://www.amazon.com/",
+      "ms": 8036,
+      "openTabs": 11
+    }
+  ],
+  "totals": {
+    "cookieEvents": 2177,
+    "cookieRemoved": 1002,
+    "tabUpdatedEvents": 68,
+    "tabUpdatedComplete": 27,
+    "tabsRemoved": 0
+  },
+  "byPhase": {
+    "ipc-bench": {
+      "cookieEvents": 0,
+      "cookieRemoved": 0,
+      "cookieByCause": {},
+      "tabUpdatedEvents": 0,
+      "tabUpdatedComplete": 0,
+      "tabUpdatedByKey": {},
+      "tabsRemoved": 0,
+      "flushes": 1
+    },
+    "browse": {
+      "cookieEvents": 2146,
+      "cookieRemoved": 986,
+      "cookieByCause": {
+        "explicit": 1160,
+        "overwrite": 695,
+        "expired_overwrite": 291
+      },
+      "tabUpdatedEvents": 68,
+      "tabUpdatedComplete": 27,
+      "tabUpdatedByKey": {
+        "status": 37,
+        "url": 15,
+        "title": 15,
+        "favIconUrl": 16
+      },
+      "tabsRemoved": 0,
+      "flushes": 10
+    },
+    "idle": {
+      "cookieEvents": 31,
+      "cookieRemoved": 16,
+      "cookieByCause": {
+        "expired": 1,
+        "overwrite": 14,
+        "explicit": 15,
+        "expired_overwrite": 1
+      },
+      "tabUpdatedEvents": 0,
+      "tabUpdatedComplete": 0,
+      "tabUpdatedByKey": {},
+      "tabsRemoved": 0,
+      "flushes": 12
+    }
+  },
+  "errors": [],
+  "finishedAt": 1785980463254
+}

--- a/tools/perf/baseline/cad-sw.json
+++ b/tools/perf/baseline/cad-sw.json
@@ -1,0 +1,148 @@
+{
+  "swUrl": "chrome-extension://fafpglpjlakbmakcioinooemcipchebk/bundles/background.js",
+  "totalMs": 278375,
+  "aliveMs": 227068,
+  "pctAlive": 81.6,
+  "coldStarts": 2,
+  "spans": [
+    {
+      "start": 1785971243585,
+      "end": 1785971267480,
+      "ms": 23895
+    },
+    {
+      "start": 1785971318787,
+      "end": 1785971521960,
+      "ms": 203173,
+      "stillAlive": true
+    }
+  ],
+  "phaseWindows": {
+    "A-quiet": {
+      "windowMs": 75008,
+      "swAliveMs": 23894,
+      "pctAlive": 31.9,
+      "coldStarts": 0
+    },
+    "B-browse": {
+      "windowMs": 80317,
+      "swAliveMs": 80124,
+      "pctAlive": 99.8,
+      "coldStarts": 1
+    },
+    "C-idle": {
+      "windowMs": 120014,
+      "swAliveMs": 120014,
+      "pctAlive": 100,
+      "coldStarts": 0
+    },
+    "D-heap": {
+      "windowMs": 3035,
+      "swAliveMs": 3035,
+      "pctAlive": 100,
+      "coldStarts": 0
+    }
+  },
+  "heap": {
+    "usedSize": 3654004,
+    "totalSize": 4718592,
+    "embedderHeapUsedSize": 1020040,
+    "backingStorageSize": 197752
+  },
+  "log": [
+    {
+      "t": 1785971243585,
+      "ev": "SW_START",
+      "url": "chrome-extension://fafpglpjlakbmakcioinooemcipchebk/bundles/"
+    },
+    {
+      "t": 1785971243586,
+      "ev": "PHASE",
+      "phase": "A-quiet",
+      "seconds": 75
+    },
+    {
+      "t": 1785971267480,
+      "ev": "SW_STOP",
+      "aliveMs": 23895
+    },
+    {
+      "t": 1785971318594,
+      "ev": "PHASE",
+      "phase": "B-browse",
+      "sites": 10
+    },
+    {
+      "t": 1785971318622,
+      "ev": "PAGE",
+      "url": "https://en.wikipedia.org/wiki/HTTP_cookie"
+    },
+    {
+      "t": 1785971318787,
+      "ev": "SW_START",
+      "url": "chrome-extension://fafpglpjlakbmakcioinooemcipchebk/bundles/"
+    },
+    {
+      "t": 1785971326649,
+      "ev": "PAGE",
+      "url": "https://www.bbc.com/news"
+    },
+    {
+      "t": 1785971334688,
+      "ev": "PAGE",
+      "url": "https://stackoverflow.com/questions"
+    },
+    {
+      "t": 1785971342715,
+      "ev": "PAGE",
+      "url": "https://github.com/explore"
+    },
+    {
+      "t": 1785971350746,
+      "ev": "PAGE",
+      "url": "https://www.reddit.com/r/programming/"
+    },
+    {
+      "t": 1785971358787,
+      "ev": "PAGE",
+      "url": "https://www.imdb.com/chart/top/"
+    },
+    {
+      "t": 1785971366812,
+      "ev": "PAGE",
+      "url": "https://www.ebay.com/"
+    },
+    {
+      "t": 1785971374839,
+      "ev": "PAGE",
+      "url": "https://weather.com/"
+    },
+    {
+      "t": 1785971382873,
+      "ev": "PAGE",
+      "url": "https://www.cnn.com/"
+    },
+    {
+      "t": 1785971390904,
+      "ev": "PAGE",
+      "url": "https://www.amazon.com/"
+    },
+    {
+      "t": 1785971398911,
+      "ev": "PHASE",
+      "phase": "C-idle",
+      "seconds": 120
+    },
+    {
+      "t": 1785971518925,
+      "ev": "PHASE",
+      "phase": "D-heap"
+    },
+    {
+      "t": 1785971521960,
+      "ev": "HEAP",
+      "usedMB": 3.48,
+      "totalMB": 4.5
+    }
+  ]
+}

--- a/tools/perf/baseline/measured.json
+++ b/tools/perf/baseline/measured.json
@@ -1,0 +1,275 @@
+{
+  "startedAt": 1785970707565,
+  "phases": [
+    {
+      "kind": "phase",
+      "phase": "start",
+      "ts": 1785970821900
+    },
+    {
+      "kind": "phase",
+      "phase": "browse-start",
+      "ts": 1785970823636
+    },
+    {
+      "kind": "phase",
+      "phase": "browse-end",
+      "ts": 1785970905532
+    },
+    {
+      "kind": "phase",
+      "phase": "idle-start",
+      "ts": 1785970905533,
+      "openTabs": 11
+    },
+    {
+      "kind": "phase",
+      "phase": "idle-end",
+      "ts": 1785970965991
+    }
+  ],
+  "ipc": [
+    {
+      "name": "tabs.query({active:true})",
+      "n": 300,
+      "mean": 0.15166666666666667,
+      "p50": 0.10000002384185791,
+      "p90": 0.20000004768371582,
+      "p99": 0.9000000357627869
+    },
+    {
+      "name": "tabs.query({windowType:normal})",
+      "n": 300,
+      "mean": 0.11766666670640309,
+      "p50": 0.10000002384185791,
+      "p90": 0.19999998807907104,
+      "p99": 0.30000001192092896
+    },
+    {
+      "name": "cookies.getAll({domain})",
+      "n": 300,
+      "mean": 0.14600000003973643,
+      "p50": 0.10000002384185791,
+      "p90": 0.20000004768371582,
+      "p99": 0.30000001192092896
+    },
+    {
+      "name": "cookies.getAll({domain:\"\"}) [FPI probe]",
+      "n": 300,
+      "mean": 0.14999999980131784,
+      "p50": 0.10000002384185791,
+      "p90": 0.20000004768371582,
+      "p99": 0.30000001192092896
+    },
+    {
+      "name": "action.setIcon(imageData)",
+      "n": 300,
+      "mean": 0.5376666667064031,
+      "p50": 0.5,
+      "p90": 0.699999988079071,
+      "p99": 0.9000000357627869
+    },
+    {
+      "name": "action.getTitle()",
+      "n": 300,
+      "mean": 0.08766666670640309,
+      "p50": 0.09999996423721313,
+      "p90": 0.19999998807907104,
+      "p99": 0.20000004768371582
+    },
+    {
+      "name": "action.setTitle()",
+      "n": 300,
+      "mean": 0.13433333337306977,
+      "p50": 0.10000002384185791,
+      "p90": 0.20000004768371582,
+      "p99": 0.3999999761581421
+    },
+    {
+      "name": "action.setBadgeText()",
+      "n": 300,
+      "mean": 0.1369999998807907,
+      "p50": 0.10000002384185791,
+      "p90": 0.20000004768371582,
+      "p99": 0.3999999761581421
+    },
+    {
+      "name": "action.setBadgeBackgroundColor()",
+      "n": 300,
+      "mean": 0.1246666665871938,
+      "p50": 0.10000002384185791,
+      "p90": 0.20000004768371582,
+      "p99": 0.3999999761581421
+    },
+    {
+      "name": "storage.local.get()",
+      "n": 300,
+      "mean": 0.09700000007947286,
+      "p50": 0.10000002384185791,
+      "p90": 0.19999998807907104,
+      "p99": 0.30000001192092896
+    },
+    {
+      "name": "storage.local.set(5KB)",
+      "n": 150,
+      "mean": 0.18666666626930237,
+      "p50": 0.19999998807907104,
+      "p90": 0.30000001192092896,
+      "p99": 0.5
+    },
+    {
+      "name": "storage.session.get()",
+      "n": 300,
+      "mean": 0.07766666690508525,
+      "p50": 0.09999996423721313,
+      "p90": 0.19999998807907104,
+      "p99": 0.20000004768371582
+    },
+    {
+      "name": "alarms.get()",
+      "n": 300,
+      "mean": 0.07133333325386047,
+      "p50": 0.09999996423721313,
+      "p90": 0.10000002384185791,
+      "p99": 0.20000004768371582
+    }
+  ],
+  "ipcLoaded": {
+    "tabCount": 11,
+    "results": [
+      {
+        "name": "tabs.query({windowType:normal}) @manyTabs",
+        "n": 200,
+        "mean": 0.2975,
+        "p50": 0.30000001192092896,
+        "p90": 0.40000003576278687,
+        "p99": 0.5
+      },
+      {
+        "name": "action.setIcon(imageData) @manyTabs",
+        "n": 200,
+        "mean": 0.5119999998807907,
+        "p50": 0.5,
+        "p90": 0.6000000238418579,
+        "p99": 0.8999999761581421
+      }
+    ]
+  },
+  "pages": [
+    {
+      "kind": "page",
+      "url": "https://en.wikipedia.org/wiki/HTTP_cookie",
+      "ms": 8029,
+      "openTabs": 2
+    },
+    {
+      "kind": "page",
+      "url": "https://www.bbc.com/news",
+      "ms": 8030,
+      "openTabs": 3
+    },
+    {
+      "kind": "page",
+      "url": "https://stackoverflow.com/questions",
+      "ms": 8037,
+      "openTabs": 4
+    },
+    {
+      "kind": "page",
+      "url": "https://github.com/explore",
+      "ms": 8029,
+      "openTabs": 5
+    },
+    {
+      "kind": "page",
+      "url": "https://www.reddit.com/r/programming/",
+      "ms": 8028,
+      "openTabs": 6
+    },
+    {
+      "kind": "page",
+      "url": "https://www.imdb.com/chart/top/",
+      "ms": 8033,
+      "openTabs": 7
+    },
+    {
+      "kind": "page",
+      "url": "https://www.ebay.com/",
+      "ms": 8037,
+      "openTabs": 8
+    },
+    {
+      "kind": "page",
+      "url": "https://weather.com/",
+      "ms": 8033,
+      "openTabs": 9
+    },
+    {
+      "kind": "page",
+      "url": "https://www.cnn.com/",
+      "ms": 8034,
+      "openTabs": 10
+    },
+    {
+      "kind": "page",
+      "url": "https://www.amazon.com/",
+      "ms": 8030,
+      "openTabs": 11
+    }
+  ],
+  "totals": {
+    "cookieEvents": 2174,
+    "cookieRemoved": 1001,
+    "tabUpdatedEvents": 69,
+    "tabUpdatedComplete": 28,
+    "tabsRemoved": 0
+  },
+  "byPhase": {
+    "ipc-bench": {
+      "cookieEvents": 0,
+      "cookieRemoved": 0,
+      "cookieByCause": {},
+      "tabUpdatedEvents": 0,
+      "tabUpdatedComplete": 0,
+      "tabUpdatedByKey": {},
+      "tabsRemoved": 0,
+      "flushes": 1
+    },
+    "browse": {
+      "cookieEvents": 2124,
+      "cookieRemoved": 977,
+      "cookieByCause": {
+        "explicit": 1147,
+        "overwrite": 686,
+        "expired_overwrite": 291
+      },
+      "tabUpdatedEvents": 69,
+      "tabUpdatedComplete": 28,
+      "tabUpdatedByKey": {
+        "status": 38,
+        "url": 15,
+        "title": 15,
+        "favIconUrl": 16
+      },
+      "tabsRemoved": 0,
+      "flushes": 10
+    },
+    "idle": {
+      "cookieEvents": 50,
+      "cookieRemoved": 24,
+      "cookieByCause": {
+        "explicit": 26,
+        "overwrite": 22,
+        "expired": 1,
+        "expired_overwrite": 1
+      },
+      "tabUpdatedEvents": 0,
+      "tabUpdatedComplete": 0,
+      "tabUpdatedByKey": {},
+      "tabsRemoved": 0,
+      "flushes": 12
+    }
+  },
+  "errors": [],
+  "finishedAt": 1785970966176
+}

--- a/tools/perf/browser-meter/manifest.json
+++ b/tools/perf/browser-meter/manifest.json
@@ -1,0 +1,11 @@
+{
+  "manifest_version": 3,
+  "name": "CAD Hot-Path Meter",
+  "version": "1.0.0",
+  "description": "Measures real extension-API IPC latency and background event rates.",
+  "minimum_chrome_version": "109",
+  "action": { "default_title": "CAD Meter" },
+  "background": { "service_worker": "sw.js" },
+  "permissions": ["alarms", "cookies", "storage", "tabs"],
+  "host_permissions": ["<all_urls>", "http://localhost/*"]
+}

--- a/tools/perf/browser-meter/sw.js
+++ b/tools/perf/browser-meter/sw.js
@@ -1,0 +1,221 @@
+/**
+ * CAD Hot-Path Meter — measures, in a real Chrome MV3 service worker:
+ *   1. real per-call latency of the extension APIs CAD uses on its hot paths
+ *   2. real cookies.onChanged / tabs.onUpdated event rates during real browsing
+ *
+ * Results are POSTed to a local collector (no data leaves the machine).
+ */
+
+const COLLECTOR = 'http://localhost:8777';
+
+const SITES = [
+  'https://en.wikipedia.org/wiki/HTTP_cookie',
+  'https://www.bbc.com/news',
+  'https://stackoverflow.com/questions',
+  'https://github.com/explore',
+  'https://www.reddit.com/r/programming/',
+  'https://www.imdb.com/chart/top/',
+  'https://www.ebay.com/',
+  'https://weather.com/',
+  'https://www.cnn.com/',
+  'https://www.amazon.com/',
+];
+
+// ---- event counters (in-memory, flushed as deltas) -------------------------
+
+let d = freshDelta();
+
+function freshDelta() {
+  return {
+    cookieEvents: 0,
+    cookieByCause: {},
+    cookieRemoved: 0,
+    tabUpdatedEvents: 0,
+    tabUpdatedByKey: {},
+    tabUpdatedComplete: 0,
+    tabsRemoved: 0,
+  };
+}
+
+function bump(obj, key) {
+  obj[key] = (obj[key] || 0) + 1;
+}
+
+chrome.cookies.onChanged.addListener((ci) => {
+  d.cookieEvents++;
+  bump(d.cookieByCause, ci.cause);
+  if (ci.removed) d.cookieRemoved++;
+});
+
+chrome.tabs.onUpdated.addListener((tabId, changeInfo, tab) => {
+  d.tabUpdatedEvents++;
+  for (const k of Object.keys(changeInfo)) bump(d.tabUpdatedByKey, k);
+  if (tab && tab.status === 'complete') d.tabUpdatedComplete++;
+});
+
+chrome.tabs.onRemoved.addListener(() => {
+  d.tabsRemoved++;
+});
+
+async function flush(phase) {
+  const payload = { kind: 'delta', phase, ...d };
+  d = freshDelta();
+  try {
+    await fetch(`${COLLECTOR}/report`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+  } catch (e) {
+    // collector not up yet; counts roll into the next flush
+    Object.assign(d, payload, { kind: undefined, phase: undefined });
+  }
+}
+
+async function send(obj) {
+  try {
+    await fetch(`${COLLECTOR}/report`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(obj),
+    });
+  } catch (e) {
+    /* ignore */
+  }
+}
+
+// ---- IPC latency benchmark -------------------------------------------------
+
+async function makeIconData() {
+  // Same technique CAD uses (BrowserActionService.loadIconData).
+  const c = new OffscreenCanvas(48, 48);
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = '#3b82f6';
+  ctx.fillRect(0, 0, 48, 48);
+  return ctx.getImageData(0, 0, 48, 48);
+}
+
+async function bench(name, fn, iterations) {
+  // warm-up
+  for (let i = 0; i < 20; i++) await fn(i);
+  const samples = [];
+  for (let i = 0; i < iterations; i++) {
+    const t0 = performance.now();
+    await fn(i);
+    samples.push(performance.now() - t0);
+  }
+  samples.sort((a, b) => a - b);
+  const sum = samples.reduce((a, b) => a + b, 0);
+  return {
+    name,
+    n: iterations,
+    mean: sum / samples.length,
+    p50: samples[Math.floor(samples.length * 0.5)],
+    p90: samples[Math.floor(samples.length * 0.9)],
+    p99: samples[Math.floor(samples.length * 0.99)],
+  };
+}
+
+async function runIpcBenchmark() {
+  const icon = await makeIconData();
+  const N = 300;
+  const results = [];
+
+  results.push(
+    await bench('tabs.query({active:true})', () => chrome.tabs.query({ active: true, windowType: 'normal' }), N),
+  );
+  results.push(
+    await bench('tabs.query({windowType:normal})', () => chrome.tabs.query({ windowType: 'normal' }), N),
+  );
+  results.push(
+    await bench('cookies.getAll({domain})', () => chrome.cookies.getAll({ domain: 'wikipedia.org' }), N),
+  );
+  results.push(
+    await bench('cookies.getAll({domain:""}) [FPI probe]', () => chrome.cookies.getAll({ domain: '' }), N),
+  );
+  results.push(await bench('action.setIcon(imageData)', () => chrome.action.setIcon({ imageData: { 48: icon } }), N));
+  results.push(await bench('action.getTitle()', () => chrome.action.getTitle({}), N));
+  results.push(await bench('action.setTitle()', () => chrome.action.setTitle({ title: 'x' }), N));
+  results.push(await bench('action.setBadgeText()', () => chrome.action.setBadgeText({ text: '' }), N));
+  results.push(
+    await bench('action.setBadgeBackgroundColor()', () => chrome.action.setBadgeBackgroundColor({ color: 'blue' }), N),
+  );
+  results.push(await bench('storage.local.get()', () => chrome.storage.local.get(), N));
+  results.push(
+    await bench('storage.local.set(5KB)', (i) => chrome.storage.local.set({ blob: 'x'.repeat(5000) + i }), 150),
+  );
+  results.push(await bench('storage.session.get()', () => chrome.storage.session.get('cache'), N));
+  results.push(await bench('alarms.get()', () => chrome.alarms.get('nope'), N));
+
+  await send({ kind: 'ipc', results });
+  return results;
+}
+
+// ---- browsing driver -------------------------------------------------------
+
+function sleep(ms) {
+  return new Promise((r) => setTimeout(r, ms));
+}
+
+async function openAndWait(url, settleMs) {
+  const tab = await chrome.tabs.create({ url, active: true });
+  await sleep(settleMs);
+  return tab.id;
+}
+
+async function run() {
+  await send({ kind: 'phase', phase: 'start', ts: Date.now() });
+
+  // Phase 1 — IPC latency, on an otherwise idle browser.
+  const ipc = await runIpcBenchmark();
+  await flush('ipc-bench');
+
+  // Phase 2 — real page loads, one at a time, tabs left open (accumulating).
+  await send({ kind: 'phase', phase: 'browse-start', ts: Date.now() });
+  const opened = [];
+  for (const url of SITES) {
+    const before = Date.now();
+    const id = await openAndWait(url, 8000);
+    opened.push(id);
+    await send({
+      kind: 'page',
+      url,
+      ms: Date.now() - before,
+      openTabs: (await chrome.tabs.query({ windowType: 'normal' })).length,
+    });
+    await flush('browse');
+  }
+  await send({ kind: 'phase', phase: 'browse-end', ts: Date.now() });
+
+  // Phase 3 — idle with all tabs still open (background cookie churn).
+  await send({ kind: 'phase', phase: 'idle-start', ts: Date.now(), openTabs: opened.length + 1 });
+  for (let i = 0; i < 12; i++) {
+    await sleep(5000);
+    await flush('idle');
+  }
+  await send({ kind: 'phase', phase: 'idle-end', ts: Date.now() });
+
+  // Phase 4 — re-measure the two costliest APIs with many tabs open, to see
+  // whether IPC latency degrades with tab count (CAD's setGlobalIcon loop).
+  const tabCount = (await chrome.tabs.query({ windowType: 'normal' })).length;
+  const loaded = [
+    await bench('tabs.query({windowType:normal}) @manyTabs', () => chrome.tabs.query({ windowType: 'normal' }), 200),
+    await bench('action.setIcon(imageData) @manyTabs', () => chrome.action.setIcon({ imageData: { 48: makeIconDataSync() } }), 200),
+  ];
+  await send({ kind: 'ipc-loaded', tabCount, results: loaded });
+
+  await send({ kind: 'done', ts: Date.now() });
+}
+
+let cachedIcon = null;
+function makeIconDataSync() {
+  if (cachedIcon) return cachedIcon;
+  const c = new OffscreenCanvas(48, 48);
+  const ctx = c.getContext('2d');
+  ctx.fillStyle = '#ef4444';
+  ctx.fillRect(0, 0, 48, 48);
+  cachedIcon = ctx.getImageData(0, 0, 48, 48);
+  return cachedIcon;
+}
+
+run().catch((e) => send({ kind: 'error', message: String(e && e.stack) }));

--- a/tools/perf/browser-meter/sw.js
+++ b/tools/perf/browser-meter/sw.js
@@ -37,8 +37,8 @@ function freshDelta() {
   };
 }
 
-function bump(obj, key) {
-  obj[key] = (obj[key] || 0) + 1;
+function bump(obj, key, by = 1) {
+  obj[key] = (obj[key] || 0) + by;
 }
 
 chrome.cookies.onChanged.addListener((ci) => {
@@ -57,8 +57,19 @@ chrome.tabs.onRemoved.addListener(() => {
   d.tabsRemoved++;
 });
 
+function addCounts(target, source) {
+  target.cookieEvents += source.cookieEvents;
+  target.cookieRemoved += source.cookieRemoved;
+  target.tabUpdatedEvents += source.tabUpdatedEvents;
+  target.tabUpdatedComplete += source.tabUpdatedComplete;
+  target.tabsRemoved += source.tabsRemoved;
+  for (const [k, v] of Object.entries(source.cookieByCause)) bump(target.cookieByCause, k, v);
+  for (const [k, v] of Object.entries(source.tabUpdatedByKey)) bump(target.tabUpdatedByKey, k, v);
+}
+
 async function flush(phase) {
   const payload = { kind: 'delta', phase, ...d };
+  const sent = d;
   d = freshDelta();
   try {
     await fetch(`${COLLECTOR}/report`, {
@@ -67,8 +78,10 @@ async function flush(phase) {
       body: JSON.stringify(payload),
     });
   } catch (e) {
-    // collector not up yet; counts roll into the next flush
-    Object.assign(d, payload, { kind: undefined, phase: undefined });
+    // collector not up yet; sum the unsent counts (plus anything counted by
+    // listeners since `d` was reset above) into the next flush instead of
+    // overwriting it, so events aren't silently lost.
+    addCounts(d, sent);
   }
 }
 

--- a/tools/perf/cad-sw-probe.js
+++ b/tools/perf/cad-sw-probe.js
@@ -1,0 +1,234 @@
+/**
+ * Measures the REAL Cookie AutoDelete MV3 service worker in a real Chromium:
+ *   - how much wall-clock time it stays resident (=> memory + cold-start count)
+ *   - how many times it cold-starts
+ *   - its JS heap size
+ *
+ * Liveness is tracked with CDP target DISCOVERY ONLY (never attaching), because
+ * attaching a debugger to a service worker suppresses Chrome's idle termination
+ * and would invalidate the lifetime measurement. A single attach happens at the
+ * very end, purely to read the heap.
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+const CDP = 'http://127.0.0.1:9222';
+// node tools/perf/cad-sw-probe.js [outDir]   (default: tools/perf/runs/latest)
+const OUT_DIR = path.resolve(process.argv[2] || path.join(__dirname, 'runs', 'latest'));
+fs.mkdirSync(OUT_DIR, { recursive: true });
+const OUT = path.join(OUT_DIR, 'cad-sw.json');
+
+const SITES = [
+  'https://en.wikipedia.org/wiki/HTTP_cookie',
+  'https://www.bbc.com/news',
+  'https://stackoverflow.com/questions',
+  'https://github.com/explore',
+  'https://www.reddit.com/r/programming/',
+  'https://www.imdb.com/chart/top/',
+  'https://www.ebay.com/',
+  'https://weather.com/',
+  'https://www.cnn.com/',
+  'https://www.amazon.com/',
+];
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function browserWs() {
+  for (let i = 0; i < 60; i++) {
+    try {
+      const v = await (await fetch(`${CDP}/json/version`)).json();
+      if (v.webSocketDebuggerUrl) return v.webSocketDebuggerUrl;
+    } catch {
+      /* not up yet */
+    }
+    await sleep(500);
+  }
+  throw new Error('CDP never came up');
+}
+
+function connect(url) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    let id = 0;
+    const pending = new Map();
+    const handlers = [];
+
+    ws.onopen = () =>
+      resolve({
+        send(method, params, sessionId) {
+          const msgId = ++id;
+          const msg = { id: msgId, method, params: params || {} };
+          if (sessionId) msg.sessionId = sessionId;
+          ws.send(JSON.stringify(msg));
+          return new Promise((res, rej) => pending.set(msgId, { res, rej }));
+        },
+        on(fn) {
+          handlers.push(fn);
+        },
+        close: () => ws.close(),
+      });
+    ws.onerror = (e) => reject(new Error('ws error ' + e.message));
+    ws.onmessage = (ev) => {
+      const m = JSON.parse(ev.data);
+      if (m.id && pending.has(m.id)) {
+        const { res, rej } = pending.get(m.id);
+        pending.delete(m.id);
+        if (m.error) rej(new Error(JSON.stringify(m.error)));
+        else res(m.result);
+      } else if (m.method) {
+        for (const h of handlers) h(m);
+      }
+    };
+  });
+}
+
+const log = [];
+function note(ev, extra) {
+  const e = { t: Date.now(), ev, ...extra };
+  log.push(e);
+  console.log(`[${new Date(e.t).toISOString().slice(11, 19)}] ${ev}${extra ? ' ' + JSON.stringify(extra) : ''}`);
+}
+
+async function main() {
+  const wsUrl = await browserWs();
+  const c = await connect(wsUrl);
+
+  // Track extension service-worker targets by discovery only.
+  let swTargetId = null;
+  let swUrl = null;
+  const spans = []; // {start, end}
+  let openedAt = null;
+
+  // Chromium also runs component-extension service workers; match CAD only.
+  const isCad = (t) =>
+    t.type === 'service_worker' && /^chrome-extension:\/\/.*\/bundles\/background\.js/.test(t.url);
+
+  c.on((m) => {
+    if (m.method === 'Target.targetCreated' || m.method === 'Target.targetInfoChanged') {
+      const t = m.params.targetInfo;
+      if (isCad(t)) {
+        if (swTargetId !== t.targetId) {
+          swTargetId = t.targetId;
+          swUrl = t.url;
+          openedAt = Date.now();
+          note('SW_START', { url: t.url.slice(0, 60) });
+        }
+      }
+    }
+    if (m.method === 'Target.targetDestroyed') {
+      if (m.params.targetId === swTargetId) {
+        const end = Date.now();
+        spans.push({ start: openedAt, end, ms: end - openedAt });
+        note('SW_STOP', { aliveMs: end - openedAt });
+        swTargetId = null;
+        openedAt = null;
+      }
+    }
+  });
+
+  await c.send('Target.setDiscoverTargets', { discover: true });
+
+  // --- Phase A: fresh browser, nothing happening -----------------------------
+  note('PHASE', { phase: 'A-quiet', seconds: 75 });
+  await sleep(75000);
+
+  // --- Phase B: real page loads ---------------------------------------------
+  note('PHASE', { phase: 'B-browse', sites: SITES.length });
+  for (const url of SITES) {
+    await c.send('Target.createTarget', { url });
+    note('PAGE', { url });
+    await sleep(8000);
+  }
+
+  // --- Phase C: idle with all tabs open --------------------------------------
+  note('PHASE', { phase: 'C-idle', seconds: 120 });
+  await sleep(120000);
+
+  // --- Phase D: one attach, purely to read the heap --------------------------
+  note('PHASE', { phase: 'D-heap' });
+  let heap = null;
+  try {
+    // Nudge the SW awake so there is something to attach to.
+    await c.send('Target.createTarget', { url: 'https://example.com/' });
+    await sleep(3000);
+    const { targetInfos } = await c.send('Target.getTargets');
+    const sw = targetInfos.find((t) => isCad(t));
+    if (sw) {
+      const { sessionId } = await c.send('Target.attachToTarget', {
+        targetId: sw.targetId,
+        flatten: true,
+      });
+      const usage = await c.send('Runtime.getHeapUsage', {}, sessionId);
+      heap = usage;
+      note('HEAP', {
+        usedMB: +(usage.usedSize / 1048576).toFixed(2),
+        totalMB: +(usage.totalSize / 1048576).toFixed(2),
+      });
+      await c.send('Target.detachFromTarget', { sessionId });
+    } else {
+      note('HEAP', { error: 'no SW target found' });
+    }
+  } catch (e) {
+    note('HEAP', { error: String(e.message) });
+  }
+
+  // close out any still-running span
+  if (openedAt) spans.push({ start: openedAt, end: Date.now(), ms: Date.now() - openedAt, stillAlive: true });
+
+  const first = log[0].t;
+  const last = log[log.length - 1].t;
+  const totalMs = last - first;
+  const aliveMs = spans.reduce((a, s) => a + s.ms, 0);
+
+  const phaseWindows = {};
+  const phases = log.filter((e) => e.ev === 'PHASE');
+  for (let i = 0; i < phases.length; i++) {
+    const start = phases[i].t;
+    const end = i + 1 < phases.length ? phases[i + 1].t : last;
+    const overlap = spans.reduce(
+      (a, s) => a + Math.max(0, Math.min(s.end, end) - Math.max(s.start, start)),
+      0,
+    );
+    phaseWindows[phases[i].phase] = {
+      windowMs: end - start,
+      swAliveMs: overlap,
+      pctAlive: +((overlap / (end - start)) * 100).toFixed(1),
+      coldStarts: log.filter((e) => e.ev === 'SW_START' && e.t >= start && e.t < end).length,
+    };
+  }
+
+  const report = {
+    swUrl,
+    totalMs,
+    aliveMs,
+    pctAlive: +((aliveMs / totalMs) * 100).toFixed(1),
+    coldStarts: spans.length,
+    spans,
+    phaseWindows,
+    heap,
+    log,
+  };
+  fs.writeFileSync(OUT, JSON.stringify(report, null, 2));
+
+  console.log('\n' + '='.repeat(70));
+  console.log('REAL CAD SERVICE WORKER — LIFETIME & MEMORY');
+  console.log('='.repeat(70));
+  console.log(`observed window : ${(totalMs / 1000).toFixed(0)}s`);
+  console.log(`SW resident     : ${(aliveMs / 1000).toFixed(0)}s (${report.pctAlive}% of the time)`);
+  console.log(`cold starts     : ${report.coldStarts}`);
+  if (heap) console.log(`JS heap         : ${(heap.usedSize / 1048576).toFixed(2)} MB used / ${(heap.totalSize / 1048576).toFixed(2)} MB total`);
+  console.log('');
+  console.log('per phase:');
+  for (const [k, v] of Object.entries(phaseWindows)) {
+    console.log(`  ${k.padEnd(10)} window ${(v.windowMs / 1000).toFixed(0).padStart(4)}s | SW alive ${String(v.pctAlive).padStart(5)}% | cold starts ${v.coldStarts}`);
+  }
+  console.log(`\n-> ${OUT}`);
+  c.close();
+  process.exit(0);
+}
+
+main().catch((e) => {
+  console.error('FAILED:', e);
+  process.exit(1);
+});

--- a/tools/perf/collector.js
+++ b/tools/perf/collector.js
@@ -1,0 +1,117 @@
+/**
+ * Local collector for the CAD Hot-Path Meter extension.
+ * Listens on :8777, accumulates metrics, writes a JSON report, exits on `done`.
+ */
+'use strict';
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+// node tools/perf/collector.js [outDir]   (default: tools/perf/runs/latest)
+const OUT_DIR = path.resolve(process.argv[2] || path.join(__dirname, 'runs', 'latest'));
+fs.mkdirSync(OUT_DIR, { recursive: true });
+const OUT = path.join(OUT_DIR, 'measured.json');
+const PORT = 8777;
+
+const state = {
+  startedAt: Date.now(),
+  phases: [],
+  ipc: null,
+  ipcLoaded: null,
+  pages: [],
+  totals: {},
+  byPhase: {},
+  errors: [],
+};
+
+function addDelta(phase, delta) {
+  const bucket = (state.byPhase[phase] = state.byPhase[phase] || {
+    cookieEvents: 0,
+    cookieRemoved: 0,
+    cookieByCause: {},
+    tabUpdatedEvents: 0,
+    tabUpdatedComplete: 0,
+    tabUpdatedByKey: {},
+    tabsRemoved: 0,
+    flushes: 0,
+  });
+  bucket.flushes++;
+  for (const k of ['cookieEvents', 'cookieRemoved', 'tabUpdatedEvents', 'tabUpdatedComplete', 'tabsRemoved']) {
+    bucket[k] += delta[k] || 0;
+    state.totals[k] = (state.totals[k] || 0) + (delta[k] || 0);
+  }
+  for (const [k, v] of Object.entries(delta.cookieByCause || {})) {
+    bucket.cookieByCause[k] = (bucket.cookieByCause[k] || 0) + v;
+  }
+  for (const [k, v] of Object.entries(delta.tabUpdatedByKey || {})) {
+    bucket.tabUpdatedByKey[k] = (bucket.tabUpdatedByKey[k] || 0) + v;
+  }
+}
+
+const server = http.createServer((req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    return res.end();
+  }
+  if (req.method !== 'POST') {
+    res.writeHead(200);
+    return res.end('ok');
+  }
+  let body = '';
+  req.on('data', (c) => (body += c));
+  req.on('end', () => {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end('{}');
+    let msg;
+    try {
+      msg = JSON.parse(body);
+    } catch {
+      return;
+    }
+    switch (msg.kind) {
+      case 'delta':
+        addDelta(msg.phase, msg);
+        break;
+      case 'ipc':
+        state.ipc = msg.results;
+        console.log('  [ipc] latency benchmark received');
+        break;
+      case 'ipc-loaded':
+        state.ipcLoaded = { tabCount: msg.tabCount, results: msg.results };
+        console.log(`  [ipc] loaded-browser re-measure received (${msg.tabCount} tabs)`);
+        break;
+      case 'page':
+        state.pages.push(msg);
+        console.log(`  [page ${state.pages.length}] ${msg.url}  (${msg.openTabs} tabs open)`);
+        break;
+      case 'phase':
+        state.phases.push(msg);
+        console.log(`  [phase] ${msg.phase}`);
+        break;
+      case 'error':
+        state.errors.push(msg.message);
+        console.log(`  [ERROR] ${msg.message}`);
+        break;
+      case 'done':
+        state.finishedAt = Date.now();
+        fs.writeFileSync(OUT, JSON.stringify(state, null, 2));
+        console.log(`\nDONE -> ${OUT}`);
+        server.close();
+        setTimeout(() => process.exit(0), 200);
+        break;
+    }
+  });
+});
+
+server.listen(PORT, '127.0.0.1', () => console.log(`collector listening on :${PORT}`));
+
+// Safety net: never hang forever.
+setTimeout(() => {
+  state.timedOut = true;
+  state.finishedAt = Date.now();
+  fs.writeFileSync(OUT, JSON.stringify(state, null, 2));
+  console.log(`\nTIMEOUT -> wrote partial report to ${OUT}`);
+  process.exit(0);
+}, 6 * 60 * 1000);

--- a/tools/perf/instrumentedBrowser.js
+++ b/tools/perf/instrumentedBrowser.js
@@ -1,0 +1,242 @@
+/**
+ * Instrumented `browser.*` mock for hot-path measurement.
+ *
+ * Unlike __tests__/setup.js (jest.fn() stubs that return undefined), this mock
+ * returns realistic payloads so the real CAD code paths actually execute, and
+ * counts every extension-API call so we can report exact IPC counts per event.
+ */
+'use strict';
+
+const calls = {};
+let ipcLatencyMs = 0;
+
+function resetCalls() {
+  for (const k of Object.keys(calls)) delete calls[k];
+}
+
+function totalCalls() {
+  return Object.values(calls).reduce((a, b) => a + b, 0);
+}
+
+function ipc(name, result) {
+  calls[name] = (calls[name] || 0) + 1;
+  if (ipcLatencyMs > 0) {
+    return new Promise((r) => setTimeout(() => r(result), ipcLatencyMs));
+  }
+  return Promise.resolve(result);
+}
+
+function sync(name, result) {
+  calls[name] = (calls[name] || 0) + 1;
+  return result;
+}
+
+// --- realistic fixtures -----------------------------------------------------
+
+const DOMAINS = [
+  'example.com', 'news.site.org', 'shop.example.net', 'video.example.io',
+  'mail.example.com', 'docs.example.org', 'forum.example.net', 'blog.example.co',
+];
+
+function makeTab(i) {
+  const d = DOMAINS[i % DOMAINS.length];
+  return {
+    id: i + 1,
+    index: i,
+    windowId: 1,
+    active: i === 0,
+    url: `https://www.${d}/page/${i}`,
+    title: `Tab ${i} - ${d}`,
+    status: 'complete',
+    cookieStoreId: '0',
+    incognito: false,
+    discarded: false,
+    favIconUrl: `https://www.${d}/favicon.ico`,
+    highlighted: i === 0,
+    pinned: false,
+    selected: i === 0,
+  };
+}
+
+function makeCookie(i, domain) {
+  return {
+    name: `cookie_${i}`,
+    value: 'v'.repeat(32),
+    domain: `.${domain}`,
+    hostOnly: false,
+    path: '/',
+    secure: true,
+    httpOnly: i % 3 === 0,
+    sameSite: 'lax',
+    session: i % 4 === 0,
+    firstPartyDomain: '',
+    storeId: '0',
+    expirationDate: 1900000000,
+  };
+}
+
+/**
+ * @param {number} tabCount how many normal tabs the profile has open
+ * @param {number} cookiesPerDomain cookies returned by cookies.getAll for a domain
+ */
+function install({ tabCount = 10, cookiesPerDomain = 25 } = {}) {
+  const tabs = Array.from({ length: tabCount }, (_, i) => makeTab(i));
+  const cookiesFor = (domain) =>
+    Array.from({ length: cookiesPerDomain }, (_, i) => makeCookie(i, domain));
+
+  const storageLocal = { data: {} };
+  const storageSession = { data: {} };
+
+  const area = (backing, label) => ({
+    get: (key) => {
+      calls[`storage.${label}.get`] = (calls[`storage.${label}.get`] || 0) + 1;
+      if (key === undefined) return Promise.resolve({ ...backing.data });
+      if (typeof key === 'string') {
+        return Promise.resolve(
+          backing.data[key] === undefined ? {} : { [key]: backing.data[key] },
+        );
+      }
+      return Promise.resolve({ ...backing.data });
+    },
+    set: (obj) => {
+      calls[`storage.${label}.set`] = (calls[`storage.${label}.set`] || 0) + 1;
+      Object.assign(backing.data, obj);
+      return Promise.resolve();
+    },
+    remove: (key) => {
+      calls[`storage.${label}.remove`] = (calls[`storage.${label}.remove`] || 0) + 1;
+      delete backing.data[key];
+      return Promise.resolve();
+    },
+    clear: () => Promise.resolve(),
+  });
+
+  const noop = () => {};
+  const listeners = {
+    addListener: noop,
+    removeListener: noop,
+    hasListener: () => false,
+    clearListeners: noop,
+  };
+
+  const browser = {
+    action: {
+      setIcon: () => ipc('action.setIcon'),
+      setTitle: () => sync('action.setTitle'),
+      getTitle: () => ipc('action.getTitle', 'Cookie AutoDelete 1.3.0 [NO LIST] (0)'),
+      setBadgeText: () => sync('action.setBadgeText'),
+      setBadgeTextColor: () => sync('action.setBadgeTextColor'),
+      setBadgeBackgroundColor: () => sync('action.setBadgeBackgroundColor'),
+      getBadgeText: () => ipc('action.getBadgeText', ''),
+    },
+    alarms: {
+      get: () => ipc('alarms.get', undefined),
+      create: () => sync('alarms.create'),
+      clear: () => ipc('alarms.clear', true),
+      clearAll: () => ipc('alarms.clearAll', true),
+      getAll: () => ipc('alarms.getAll', []),
+      onAlarm: listeners,
+    },
+    browsingData: {
+      remove: () => ipc('browsingData.remove'),
+    },
+    cookies: {
+      getAll: (details) => {
+        calls['cookies.getAll'] = (calls['cookies.getAll'] || 0) + 1;
+        const dom = (details && details.domain) || '';
+        if (dom === '') return Promise.resolve([]); // isFirstPartyIsolate probe
+        return Promise.resolve(cookiesFor(dom.replace(/^\./, '')));
+      },
+      getAllCookieStores: () => ipc('cookies.getAllCookieStores', [{ id: '0', tabIds: [] }]),
+      get: () => ipc('cookies.get', null),
+      set: () => ipc('cookies.set', {}),
+      remove: () => ipc('cookies.remove', {}),
+      onChanged: listeners,
+    },
+    i18n: { getMessage: (k) => sync('i18n.getMessage', k) },
+    contextMenus: undefined, // measured separately; not part of the hot paths
+    notifications: { create: () => ipc('notifications.create') },
+    privacy: { websites: { firstPartyIsolate: { get: () => ipc('privacy.get', { value: false }) } } },
+    runtime: {
+      getManifest: () => sync('runtime.getManifest', { name: 'Cookie AutoDelete', version: '1.3.0' }),
+      getURL: (p) => sync('runtime.getURL', `chrome-extension://abcdef/${p}`),
+      getPlatformInfo: () => ipc('runtime.getPlatformInfo', { os: 'win', arch: 'x86-64' }),
+      getBrowserInfo: undefined, // Chrome
+      openOptionsPage: () => ipc('runtime.openOptionsPage'),
+      onConnect: listeners,
+      onInstalled: listeners,
+      onMessage: listeners,
+      onStartup: listeners,
+      onSuspend: listeners,
+      id: 'abcdef',
+    },
+    storage: {
+      local: area(storageLocal, 'local'),
+      session: area(storageSession, 'session'),
+      sync: area({ data: {} }, 'sync'),
+      managed: area({ data: {} }, 'managed'),
+      onChanged: listeners,
+    },
+    tabs: {
+      TAB_ID_NONE: -1,
+      query: (q) => {
+        calls['tabs.query'] = (calls['tabs.query'] || 0) + 1;
+        if (q && q.active) return Promise.resolve(tabs.filter((t) => t.active));
+        return Promise.resolve(tabs);
+      },
+      get: (id) => ipc('tabs.get', tabs.find((t) => t.id === id)),
+      create: () => ipc('tabs.create', makeTab(999)),
+      onUpdated: listeners,
+      onRemoved: listeners,
+    },
+    extension: { isAllowedIncognitoAccess: () => ipc('extension.incognito', false) },
+    contextualIdentities: undefined, // Chrome
+  };
+
+  global.browser = browser;
+  global.chrome = browser;
+  global.navigator = {
+    userAgent:
+      'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36',
+  };
+
+  // Globals BrowserActionService.loadIconData needs (browser-only APIs).
+  global.fetch = () => {
+    calls['fetch(icon)'] = (calls['fetch(icon)'] || 0) + 1;
+    return Promise.resolve({ ok: true, status: 200, blob: () => Promise.resolve({ size: 1024 }) });
+  };
+  global.createImageBitmap = () => {
+    calls['createImageBitmap'] = (calls['createImageBitmap'] || 0) + 1;
+    return Promise.resolve({ width: 48, height: 48, close: noop });
+  };
+  global.OffscreenCanvas = class {
+    constructor(w, h) {
+      this.width = w;
+      this.height = h;
+    }
+    getContext() {
+      return {
+        drawImage: noop,
+        getImageData: (x, y, w, h) => ({
+          width: w,
+          height: h,
+          data: new Uint8ClampedArray(w * h * 4),
+        }),
+      };
+    }
+  };
+
+  return { browser, tabs, storageLocal, storageSession };
+}
+
+module.exports = {
+  install,
+  calls,
+  resetCalls,
+  totalCalls,
+  makeTab,
+  makeCookie,
+  setIpcLatency: (ms) => {
+    ipcLatencyMs = ms;
+  },
+};

--- a/tools/perf/report.js
+++ b/tools/perf/report.js
@@ -1,0 +1,198 @@
+/**
+ * Final cost model.
+ *
+ * Inputs, all measured:
+ *   measured.json  - real Chromium: per-API IPC latency + background event rates
+ *   cad-sw.json    - real CAD service worker: residency, cold starts, JS heap
+ *   COUNTS below   - exact API-call counts per event, from the Node harness
+ *                    running the real CAD code (__tests__/perf/hotpaths.test.ts)
+ *
+ * Latency uses MEAN, not p50: performance.now() in a service worker is coarsened
+ * to 100us, so p50 collapses to 0.100 for almost every API and understates cost.
+ */
+'use strict';
+const fs = require('fs');
+const path = require('path');
+
+// Which run to report on. Defaults to the recorded baseline.
+//   node tools/perf/report.js                     -> tools/perf/baseline
+//   node tools/perf/report.js tools/perf/runs/after
+const DATA = process.argv[2]
+  ? path.resolve(process.argv[2])
+  : path.join(__dirname, 'baseline');
+
+const m = JSON.parse(fs.readFileSync(path.join(DATA, 'measured.json'), 'utf8'));
+let sw = null;
+try {
+  sw = JSON.parse(fs.readFileSync(path.join(DATA, 'cad-sw.json'), 'utf8'));
+} catch {
+  /* probe may not have run */
+}
+console.log(`# data: ${DATA}\n`);
+
+const L = {};
+for (const r of m.ipc) L[r.name] = r.mean;
+L['action.setBadgeTextColor()'] = L['action.setBadgeText()']; // not benched separately
+
+const f = (n, d = 2) => (n === null || n === undefined ? 'n/a' : Number(n).toFixed(d));
+const line = (c = '=') => console.log(c.repeat(76));
+
+// --- exact API-call counts from the harness --------------------------------
+const COUNTS = {
+  coldInit: (tabs) => ({
+    'action.setIcon(imageData)': 2 + tabs,
+    'tabs.query({windowType:normal})': 1,
+    'tabs.query({active:true})': 1,
+    'storage.local.get()': 1,
+    'storage.session.get()': 2,
+    'cookies.getAll({domain:""}) [FPI probe]': 1,
+    'action.getTitle()': 1,
+    'action.setTitle()': 1,
+    'action.setBadgeBackgroundColor()': 1,
+  }),
+  cookieOnChanged: { 'tabs.query({active:true})': 1 },
+  getAllCookieActions: {
+    'cookies.getAll({domain})': 1,
+    'cookies.getAll({domain:""}) [FPI probe]': 1,
+    'action.getTitle()': 1,
+    'action.setTitle()': 1,
+    'action.setIcon(imageData)': 1,
+    'action.setBadgeBackgroundColor()': 1,
+    'action.setBadgeText()': 1,
+    'action.setBadgeTextColor()': 1,
+  },
+  reduxDispatch: {
+    'tabs.query({active:true})': 1,
+    'action.getTitle()': 1,
+    'action.setTitle()': 1,
+    'action.setIcon(imageData)': 1,
+    'action.setBadgeBackgroundColor()': 1,
+  },
+};
+const JS = { cookieOnChanged: 0.033, getAllCookieActions: 0.115, reduxDispatch: 0.135, coldInit: 0.6 };
+
+const cost = (counts) =>
+  Object.entries(counts).reduce((a, [k, n]) => a + (L[k] || 0) * n, 0);
+
+const ph = m.byPhase;
+const phSecs = (a, b) => {
+  const s = m.phases.find((p) => p.phase === a);
+  const e = m.phases.find((p) => p.phase === b);
+  return (e.ts - s.ts) / 1000;
+};
+const browseSecs = phSecs('browse-start', 'browse-end');
+const idleSecs = phSecs('idle-start', 'idle-end');
+
+const cookiesPerHBrowse = (ph.browse.cookieEvents / browseSecs) * 3600;
+const cookiesPerHIdle = (ph.idle.cookieEvents / idleSecs) * 3600;
+const pagesPerHBrowse = (m.pages.length / browseSecs) * 3600;
+
+line();
+console.log('MEASURED INPUTS');
+line();
+console.log(`Browsing: ${m.pages.length} real page loads in ${f(browseSecs, 0)}s`);
+console.log(`  cookies.onChanged  ${ph.browse.cookieEvents} events = ${f(ph.browse.cookieEvents / m.pages.length, 0)} per page load`);
+console.log(`                     causes ${JSON.stringify(ph.browse.cookieByCause)}`);
+console.log(`  tabs.onUpdated     ${ph.browse.tabUpdatedEvents} events = ${f(ph.browse.tabUpdatedEvents / m.pages.length, 1)} per page load (${ph.browse.tabUpdatedComplete} with status:complete)`);
+console.log(`Idle (${f(idleSecs, 0)}s, 11 tabs open, no interaction)`);
+console.log(`  cookies.onChanged  ${ph.idle.cookieEvents} events = ${f(cookiesPerHIdle, 0)}/hour`);
+console.log(`  tabs.onUpdated     ${ph.idle.tabUpdatedEvents} events`);
+console.log('');
+console.log('Costliest APIs (mean ms per call):');
+for (const k of ['action.setIcon(imageData)', 'tabs.query({active:true})', 'cookies.getAll({domain})', 'storage.local.set(5KB)', 'action.getTitle()']) {
+  console.log(`  ${k.padEnd(42)} ${f(L[k], 3)}`);
+}
+console.log('');
+
+line();
+console.log('PER-EVENT COST  (measured API counts x measured mean latency)');
+line();
+const cCookie = cost(COUNTS.cookieOnChanged) + JS.cookieOnChanged;
+const cPage = cost(COUNTS.getAllCookieActions) + JS.getAllCookieActions;
+const cDisp = cost(COUNTS.reduxDispatch) + JS.reduxDispatch;
+console.log(`cookies.onChanged   1 API call   ${f(cCookie, 3)} ms   <- paid on EVERY cookie write in the browser`);
+console.log(`getAllCookieActions 8 API calls  ${f(cPage, 3)} ms   <- debounced to at most 1 per 750 ms`);
+console.log(`one redux dispatch  5 API calls  ${f(cDisp, 3)} ms   <- any state change, via SettingService`);
+console.log('');
+console.log('Cold service-worker init:');
+for (const t of [1, 10, 30, 60]) {
+  const c = COUNTS.coldInit(t);
+  console.log(`  ${String(t).padStart(2)} tabs open  ${String(Object.values(c).reduce((a, b) => a + b, 0)).padStart(3)} API calls  ${f(cost(c) + JS.coldInit, 2).padStart(6)} ms`);
+}
+console.log('');
+
+line();
+console.log('CPU PER HOUR');
+line();
+// getAllCookieActions rate is bounded: >=1 per page load, <=1.33/s while
+// same-domain cookie traffic is continuous. Report both ends.
+function hour(label, cookiesH, pagesH, activeFraction) {
+  const cookieMs = cookiesH * cCookie;
+  const lo = pagesH * cPage;
+  const hi = activeFraction * 3600 * (1 / 0.75) * cPage;
+  console.log(label);
+  console.log(`  cookie events   ${f(cookiesH, 0).padStart(7)}/h  -> ${f(cookieMs / 1000).padStart(6)} s/h`);
+  console.log(`  getAllCookieActions        -> ${f(lo / 1000)} s/h (min, 1/page) .. ${f(hi / 1000)} s/h (max, debounce-saturated)`);
+  console.log(`  TOTAL                      -> ${f((cookieMs + lo) / 1000)} .. ${f((cookieMs + hi) / 1000)} s CPU per hour`);
+  console.log(`                                = ${f(((cookieMs + lo) / 36000), 3)} .. ${f(((cookieMs + hi) / 36000), 3)} % of one core`);
+  console.log('');
+  return [(cookieMs + lo) / 1000, (cookieMs + hi) / 1000];
+}
+
+const heavy = hour('SUSTAINED HEAVY BROWSING (at the measured rate, all hour):', cookiesPerHBrowse, pagesPerHBrowse, 1.0);
+const idle = hour('IDLE, tabs left open:', cookiesPerHIdle, 0, 0);
+const mixed = hour('MIXED DAY (20% browsing at measured rate, 80% idle):', 0.2 * cookiesPerHBrowse + 0.8 * cookiesPerHIdle, 0.2 * pagesPerHBrowse, 0.2);
+
+const J = 3; // ~3 J per CPU-second, mid-range for a laptop core under light load
+const BATT = 60 * 3600; // 60 Wh in joules
+line();
+console.log(`ENERGY  (~${J} J per CPU-second, 60 Wh battery)`);
+line();
+for (const [lbl, r] of [['heavy browsing', heavy], ['idle', idle], ['mixed day', mixed]]) {
+  console.log(`  ${lbl.padEnd(16)} ${f(r[0] * J).padStart(6)} .. ${f(r[1] * J).padStart(6)} J/h  =  ${f((r[0] * J / BATT) * 100, 4)} .. ${f((r[1] * J / BATT) * 100, 4)} % of battery per hour`);
+}
+console.log('');
+console.log(`  Over a 10-hour mixed day: ${f((mixed[0] * J * 10 / BATT) * 100, 3)} .. ${f((mixed[1] * J * 10 / BATT) * 100, 3)} % of one full charge.`);
+console.log('');
+
+if (sw) {
+  line();
+  console.log('REAL CAD SERVICE WORKER (measured via CDP, no debugger attached)');
+  line();
+  console.log(`observed        : ${f(sw.totalMs / 1000, 0)}s`);
+  console.log(`SW resident     : ${f(sw.aliveMs / 1000, 0)}s = ${sw.pctAlive}% of the time`);
+  console.log(`cold starts     : ${sw.coldStarts}`);
+  if (sw.heap) console.log(`JS heap         : ${f(sw.heap.usedSize / 1048576)} MB used / ${f(sw.heap.totalSize / 1048576)} MB allocated`);
+  console.log('');
+  for (const [k, v] of Object.entries(sw.phaseWindows)) {
+    console.log(`  ${k.padEnd(10)} window ${f(v.windowMs / 1000, 0).padStart(4)}s | SW alive ${String(v.pctAlive).padStart(5)}% | cold starts ${v.coldStarts}`);
+  }
+  console.log('');
+  const coldMs = cost(COUNTS.coldInit(11)) + JS.coldInit;
+  console.log(`Each cold start costs ${f(coldMs, 2)} ms (11 tabs). ${sw.coldStarts} cold starts = ${f((sw.coldStarts * coldMs) / 1000, 2)} s over the run.`);
+  console.log('');
+}
+
+line();
+console.log('WHAT EACH OPTION ACTUALLY SAVES');
+line();
+console.log(`A) "Clean only at startup", as proposed (gate only the cleanup):`);
+console.log(`     cookies.onChanged and tabs.onUpdated are NOT gated on ACTIVE_MODE,`);
+console.log(`     so all of the per-hour cost above remains. Saving: the cleanup pass only.`);
+console.log('');
+console.log(`B) Same, but also stop registering the observation listeners:`);
+console.log(`     saves ${f(mixed[0])} .. ${f(mixed[1])} s CPU/h on a mixed day`);
+console.log(`     = ${f((mixed[0] * J / BATT) * 100, 4)} .. ${f((mixed[1] * J / BATT) * 100, 4)} % of battery per hour`);
+console.log(`     but loses the cookie-count badge and per-site icon colours.`);
+console.log('');
+console.log(`C) Fix the three hot paths (no behaviour change, helps ALL users):`);
+const fix1 = cost(COUNTS.reduxDispatch) + JS.reduxDispatch;
+const cold60 = cost(COUNTS.coldInit(60));
+const cold60fix = cost(COUNTS.coldInit(0)) - 2 * L['action.setIcon(imageData)'];
+console.log(`     #1 dispatch -> checkIfProtected  : ${f(fix1, 3)} ms per state change, removed`);
+console.log(`     #2 setGlobalIcon O(tabs) on init : ${f(cold60, 2)} -> ${f(cold60fix, 2)} ms at 60 tabs (-${f(100 - (cold60fix / cold60) * 100, 0)}%)`);
+console.log(`     #3 isFirstPartyIsolate() probe   : ${f(L['cookies.getAll({domain:""}) [FPI probe]'], 3)} ms per page load, cacheable to 0`);
+console.log('');
+console.log(`   Biggest single lever not in that list: filter cookies.onChanged BEFORE`);
+console.log(`   tabs.query. At ${f(ph.browse.cookieEvents / m.pages.length, 0)} events per page load that one call is`);
+console.log(`   ${f((cookiesPerHBrowse * cCookie) / 1000)} of the ${f(heavy[0])} s/h floor under heavy browsing.`);

--- a/tools/perf/report.js
+++ b/tools/perf/report.js
@@ -45,6 +45,9 @@ const COUNTS = {
     'tabs.query({active:true})': 1,
     'storage.local.get()': 1,
     'storage.session.get()': 2,
+    // This is detectPartitionedCookieSupport (CHIPS) at lifecycle.ts:129, not the
+    // FPI probe. Priced with the FPI probe's latency as the nearest measured
+    // equivalent — both are a single cookies.getAll (0.150 vs 0.146 ms).
     'cookies.getAll({domain:""}) [FPI probe]': 1,
     'action.getTitle()': 1,
     'action.setTitle()': 1,

--- a/tools/perf/report.js
+++ b/tools/perf/report.js
@@ -30,6 +30,32 @@ try {
 }
 console.log(`# data: ${DATA}\n`);
 
+// COUNTS below models the code as of branch base d43ee51 (pre Tasks 1-3). Warn
+// loudly whenever this is pointed anywhere except the recorded baseline, since
+// the printed per-event costs and "what each option saves" section are only
+// meaningful against that pre-change code.
+if (path.basename(DATA) !== 'baseline') {
+  console.log('!'.repeat(76));
+  console.log(
+    "WARNING: COUNTS in this file models the PRE-CHANGE code (branch base d43ee51).",
+  );
+  console.log(
+    `It has not been updated for whatever produced ${path.relative(process.cwd(), DATA)}/,`,
+  );
+  console.log(
+    'so every API-call-derived number below (per-event cost, cold-init totals,',
+  );
+  console.log(
+    '"what each option saves") is baseline-only and does NOT reflect that run\'s',
+  );
+  console.log(
+    'actual code. For authoritative post-change call counts, run `npm run test:perf`',
+  );
+  console.log('instead — it counts calls from the real code, not this hand-maintained model.');
+  console.log('!'.repeat(76));
+  console.log('');
+}
+
 const L = {};
 for (const r of m.ipc) L[r.name] = r.mean;
 L['action.setBadgeTextColor()'] = L['action.setBadgeText()']; // not benched separately
@@ -38,6 +64,14 @@ const f = (n, d = 2) => (n === null || n === undefined ? 'n/a' : Number(n).toFix
 const line = (c = '=') => console.log(c.repeat(76));
 
 // --- exact API-call counts from the harness --------------------------------
+// This is a hand-maintained model of the PRE-CHANGE code at branch base
+// d43ee51 (before Tasks 1-3: the per-tab icon loop on init, the unfiltered
+// store subscriber, the unmemoised FPI probe). It was never updated alongside
+// those tasks and no longer matches HEAD. The authoritative, code-derived
+// post-change call counts come from `npm run test:perf`
+// (__tests__/perf/hotpaths.test.ts), not from this constant — treat anything
+// below that's computed FROM these counts (per-event cost, cold-init totals,
+// "what each option saves") as baseline-only.
 const COUNTS = {
   coldInit: (tabs) => ({
     'action.setIcon(imageData)': 2 + tabs,


### PR DESCRIPTION
## Why

This started as a different question: would a "clean cookies only once at startup" mode save battery and memory?

I built a measurement harness to answer it. The answer was **no** — the whole extension costs **0.056–0.075% of a battery charge over a 10-hour day**, and the proposed mode would have saved almost nothing anyway, because `cookies.onChanged` and `tabs.onUpdated` are not gated on `ACTIVE_MODE`. That mode is dropped.

What the measurements did surface is a small set of paths doing unnecessary work, and one real bug. **This PR is not justified by CPU savings** — steady-state gain is around 1 s/hour. It is justified by the bug fix, the startup burst, and clearing the ground for the round that matters.

## Changes

**Icon writing** — `setGlobalIcon` looped over every open tab and ran inside `init()` on every service-worker wake. That erased the per-site colours `setIconColor` sets, and the `checkIfProtected` right after only repairs *active* tabs, so background tabs stayed uncoloured until revisited. Split into `setGlobalIcon` (default icon only, used by init) and `resetAllTabIcons` (keeps the loop, used by the Active Mode toggle where clearing overrides is the point).

**Store subscriptions** — `SettingService.onSettingsChange` was subscribed to the whole store, so it ran on every dispatch and ended in `checkIfProtected()`: five extension-API calls, including the most expensive one the extension makes. It behaves as a settings-only listener; now it is wired as one, with a second subscription covering `lists` changes.

**Duplicate icon refresh** — the five list-mutating thunks in `Actions.ts` each called `checkIfProtected` on top of that subscription, so it ran twice per whitelist/greylist edit. Removed; the subscription is now the single trigger.

**First-party-isolation probe** — `isFirstPartyIsolate` ran a `cookies.getAll` on every call to answer a browser-capability question that cannot change while the worker lives. Now memoised, and deliberately does *not* cache an inconclusive error.

**`tabs.onActivated`** — removing the init loop also removed an accidental repair: a tab backgrounded during a list edit kept a stale colour, because nothing repainted it. The newly-activated tab is now repainted, which is O(1) per switch rather than O(open tabs) per edit.

## Measured effect

| | Before | After |
|---|---|---|
| Cold-init API calls at 1 / 10 / 30 / 60 tabs | 21 / 30 / 50 / 80 | flat 19 |
| `getAllCookieActions` x200 -> `cookies.getAll` | 400 | 200 |
| Dispatch touching an unrelated slice | 5-6 calls | 0 |
| Service-worker residency / JS heap | 81.6% / 3.48 MB | unchanged |

Tab-count scaling on startup is gone. Steady-state CPU barely moves, as expected.

## Measurement harness

`tools/perf/` and `__tests__/perf/` — not shipped in the extension bundle. Three measurements: exact extension-API call counts from the real code (deterministic, the honest A/B signal), per-API IPC latency and background event rates from a live Chromium, and service-worker residency plus heap over CDP. Baseline and methodology in `tools/perf/README.md` and `tools/perf/baseline/RESULTS.md`. Runs via `npm run test:perf`, excluded from `npm test`.

## Notes

- **No version bump**, so merging this does not cut a release. The `1.3.1` release-notes entry is added under the version these changes are expected to ship in. Whoever cuts it must bump to exactly `1.3.1` — `Welcome.tsx` renders release notes without version gating.
- Fixed along the way: the `test` script used a jest array option, so `npm test -- <path>` silently ran everything *except* the named file and exited green.

## Known, not fixed here

- **The real cost is untouched.** `CookieEvents.onCookieChanged` pays an unconditional `tabs.query` on **212 events per page load** — 96% of steady-state cost. Removing it needs a cached active-tab domain with a cold-wake fallback, which touches MV3 wake semantics. Its own round.
- **Pre-existing bug found during verification:** `TabEvents.onTabUpdate` uses a single non-per-tab `onTabUpdateDelay` boolean, so concurrent tab-complete events are dropped rather than queued and a tab's icon update can be skipped during bursty loads such as session restore.
- May relate to #87 (Brave crashing shortly after startup, with auto-cleaning off). The startup burst this removes is a plausible mechanism, but unproven — no Brave here and no reproduction on Chrome.

## Verification

572 tests pass, lint clean at `--max-warnings 0`, webpack build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKdQqpRWqr5EQGkerng7vv