### PR TITLE
fix: site data no longer cleaned just because a cookie expired (v1.3.1)

### DIFF
--- a/__tests__/services/CleanupService.spec.ts
+++ b/__tests__/services/CleanupService.spec.ts
@@ -1505,7 +1505,7 @@ describe('CleanupService', () => {
       const result = filterSiteData(cleanReasonObj, SiteDataType.LOCALSTORAGE);
       expect(result).toBe(false);
     });
-    it('should return true because of restart cleanup and is expired cookie on restart.  Edge case => usually notInAnyList takes precidence already.', () => {
+    it('should return false because an expired cookie on restart with no matched expression has no site data opt-in.  Unlisted hosts are already covered by notInAnyList.', () => {
       const cleanReasonObj: CleanReasonObject = {
         cached: false,
         cleanCookie: true,
@@ -1516,7 +1516,33 @@ describe('CleanupService', () => {
         reason: ReasonClean.ExpiredCookieRestart,
       };
       const result = filterSiteData(cleanReasonObj, SiteDataType.LOCALSTORAGE);
-      expect(result).toBe(true);
+      expect(result).toBe(false);
+    });
+    it('should return false because an expired cookie with no matched expression has no site data opt-in.', () => {
+      const cleanReasonObj: CleanReasonObject = {
+        cached: false,
+        cleanCookie: true,
+        cookie: {
+          ...restartCleanCookie,
+        },
+        openTabStatus: OpenTabStatus.TabsWasNotIgnored,
+        reason: ReasonClean.ExpiredCookie,
+      };
+      const result = filterSiteData(cleanReasonObj, SiteDataType.LOCALSTORAGE);
+      expect(result).toBe(false);
+    });
+    it('should return false because a cookie kept by a matched expression never opts its site data in.', () => {
+      const cleanReasonObj: CleanReasonObject = {
+        cached: false,
+        cleanCookie: false,
+        cookie: {
+          ...restartCleanCookie,
+        },
+        openTabStatus: OpenTabStatus.TabsWasNotIgnored,
+        reason: ReasonKeep.MatchedExpression,
+      };
+      const result = filterSiteData(cleanReasonObj, SiteDataType.LOCALSTORAGE);
+      expect(result).toBe(false);
     });
     it('should return false because of whitelist expression and is expired cookie.', () => {
       const cleanReasonObj: CleanReasonObject = {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "description": "__MSG_extensionDescription__",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "default_locale": "en",
   "homepage_url": "https://github.com/vasilisplavos/Cookie-AutoDeleteV3",
   "author": "Vasilis Plavos",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cookie-autodelete-v3",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "cookie-autodelete-v3",
-      "version": "1.3.0",
+      "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
         "@fortawesome/fontawesome-svg-core": "^6.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cookie-autodelete-v3",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Chrome browser extension that auto-deletes unwanted cookies and site data",
   "keywords": [
     "cookie",

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -792,6 +792,28 @@ export const parseCleanSiteData = (bool?: boolean): boolean => {
   return bool === undefined ? false : bool;
 };
 
+// Reason membership as sets rather than `obj.reason === X || obj.reason === Y`
+// chains. That chain shape is what hid a bug here for two years: drop one
+// `obj.reason ===` and the operand becomes a bare enum member, which is truthy,
+// so the condition silently reads as always-true with no type or runtime error.
+type CleanupReason = ReasonKeep | ReasonClean;
+
+const NO_MATCHED_EXPRESSION_REASONS: ReadonlyArray<CleanupReason> = [
+  ReasonClean.NoMatchedExpression,
+  ReasonClean.StartupNoMatchedExpression,
+];
+
+const CAD_SITE_DATA_REASONS: ReadonlyArray<CleanupReason> = [
+  ReasonClean.CADSiteDataCookie,
+  ReasonClean.CADSiteDataCookieRestart,
+];
+
+// Restart reasons that only clean when the matched expression is greylisted.
+const GREY_ONLY_RESTART_REASONS: ReadonlyArray<CleanupReason> = [
+  ReasonClean.ExpiredCookieRestart,
+  ReasonClean.CADSiteDataCookieRestart,
+];
+
 /** Filter the deleted cookies from site data type */
 export const filterSiteData = (
   obj: CleanReasonObject,
@@ -799,24 +821,18 @@ export const filterSiteData = (
   debug = false,
 ): boolean => {
   const notProtectedByOpenTab = obj.reason !== ReasonKeep.OpenTabs;
-  const notInAnyLists =
-    obj.reason === ReasonClean.NoMatchedExpression ||
-    obj.reason === ReasonClean.StartupNoMatchedExpression;
-  const isExpiredNotRestart = obj.reason === ReasonClean.ExpiredCookie;
+  const notInAnyLists = NO_MATCHED_EXPRESSION_REASONS.includes(obj.reason);
   const isExpiredRestart = obj.reason === ReasonClean.ExpiredCookieRestart;
   const isCADCookieNoExpression =
-    (obj.reason === ReasonClean.CADSiteDataCookie ||
-      obj.reason === ReasonClean.CADSiteDataCookieRestart) &&
-    obj.expression === undefined;
+    CAD_SITE_DATA_REASONS.includes(obj.reason) && obj.expression === undefined;
   const nonBlankCookieHostName = obj.cookie.hostname.trim() !== '';
   const cleanSiteDataInExpression = parseCleanSiteData(
     obj.expression?.cleanSiteData?.includes(siteData),
   );
   const isRestartCleanup =
-    (isExpiredRestart && obj.expression?.listType === ListType.GREY) ||
-    (obj.reason === ReasonClean.CADSiteDataCookieRestart &&
-      obj.expression?.listType === ListType.GREY) ||
-    obj.reason === ReasonClean.StartupCleanupAndGreyList;
+    obj.reason === ReasonClean.StartupCleanupAndGreyList ||
+    (GREY_ONLY_RESTART_REASONS.includes(obj.reason) &&
+      obj.expression?.listType === ListType.GREY);
   const canCleanSiteData =
     isCADCookieNoExpression || cleanSiteDataInExpression || isRestartCleanup;
   const cro: CleanReasonObject = {
@@ -833,7 +849,7 @@ export const filterSiteData = (
         notProtectedByOpenTab,
         notInAnyLists,
         siteData,
-        isExpiredNotRestart,
+        isExpiredNotRestart: obj.reason === ReasonClean.ExpiredCookie,
         isExpiredRestart,
         isCADCookieNoExpression,
         cleanSiteDataInExpression,

--- a/src/services/CleanupService.ts
+++ b/src/services/CleanupService.ts
@@ -806,7 +806,7 @@ export const filterSiteData = (
   const isExpiredRestart = obj.reason === ReasonClean.ExpiredCookieRestart;
   const isCADCookieNoExpression =
     (obj.reason === ReasonClean.CADSiteDataCookie ||
-      ReasonClean.CADSiteDataCookieRestart) &&
+      obj.reason === ReasonClean.CADSiteDataCookieRestart) &&
     obj.expression === undefined;
   const nonBlankCookieHostName = obj.cookie.hostname.trim() !== '';
   const cleanSiteDataInExpression = parseCleanSiteData(

--- a/src/ui/settings/ReleaseNotes.json
+++ b/src/ui/settings/ReleaseNotes.json
@@ -6,7 +6,8 @@
         "Fixed the toolbar icon losing its per-site colour on background tabs after the extension's background worker restarted.",
         "The extension now does less work when your browser starts with many tabs open.",
         "Removed repeated internal checks that ran on every page load and on unrelated internal updates.",
-        "The toolbar icon now updates as soon as you switch to a tab, so a site you added to a list while its tab sat in the background no longer shows the old colour."
+        "The toolbar icon now updates as soon as you switch to a tab, so a site you added to a list while its tab sat in the background no longer shows the old colour.",
+        "Fixed a faulty check that could clear a site's cache, storage and service workers merely because one of its cookies had expired, without that site's data cleanup ever having been asked for."
       ]
     },
     {


### PR DESCRIPTION
## The bug

`filterSiteData` was missing one `obj.reason ===`:

```diff
  const isCADCookieNoExpression =
    (obj.reason === ReasonClean.CADSiteDataCookie ||
-      ReasonClean.CADSiteDataCookieRestart) &&
+      obj.reason === ReasonClean.CADSiteDataCookieRestart) &&
    obj.expression === undefined;
```

`ReasonClean.CADSiteDataCookieRestart` on its own is a truthy enum member, so the `||` was always true and the whole condition collapsed to `obj.expression === undefined`.

**Effect:** a site's cache, IndexedDB, localStorage and service workers were wiped whenever one of its cookies expired and the host matched no list entry — with nobody ever asking for that site's data to be cleaned.

## Why it went unnoticed for two years

Reviewed the history rather than guessing:

- The typo entered in upstream `e500d76` (PR #1397, Jun 2022). Both enum members already existed at that point, so it was a same-sitting slip, not a check left stale by a later addition.
- It only became **reachable** in upstream `cfced19` (PR #1450, Nov 2022), which reordered `isSafeToClean` so the expired-cookie branch runs *before* the no-match branch and returns `expression: matchedExpression` — `undefined` for an unlisted host. From then on, any expired cookie on an unlisted domain hit the broken condition.
- That same commit added the test that pinned the wrong behaviour, commented as `usually notInAnyList takes precedence already` — an edge case in the author's mind, but by then the common path. This PR retitles and flips it.
- Nothing else was built on the always-true behaviour. `isRestartCleanup`, the other consumer of these reasons, independently requires a greylisted expression.

## Hardening

The bug survived because of the *shape* of the code, not the logic. `obj.reason === A || obj.reason === B` degrades silently when one comparison is dropped — no type error, no runtime error.

Three conditions in this function had that shape; they are now set membership against named `ReadonlyArray`s, where dropping a comparison is not expressible. Also folded a duplicated `&& listType === GREY` guard, and inlined a local that looked like a decision input but only reached the debug log.

Behaviour-preserving: `||` is commutative and the duplicated guard factors out exactly. Kept in a **separate commit** from the fix so review and `git bisect` can tell them apart.

I checked the rest of `src/` for the same shape — no other instances.

## Release

Bumps to **1.3.1**. The `1.3.1` release-notes entry landed with #90 but the version stayed at 1.3.0, so `Welcome.tsx` (which renders the top five entries with no version gating) showed a 1.3.1 heading inside a 1.3.0 build, and `release-on-main` published nothing because `v1.3.0` already existed. Merging this cuts **v1.3.1**.

`package-lock.json`'s two version fields are synced by hand rather than via `npm install`, to keep the diff to the version alone and avoid moving dependency resolutions.

## Verification

574 tests pass, lint clean at `--max-warnings 0`, webpack build green.

Three assertions fail if the fix is reverted — traced through the full function body, not just the changed condition, to confirm `isCADCookieNoExpression` is the sole swing variable in each:

- `CleanupService.spec.ts` — `ExpiredCookieRestart`, no expression
- `CleanupService.spec.ts` — `ExpiredCookie`, no expression (the reported symptom)
- `CleanupService.spec.ts` — `ReasonKeep.MatchedExpression`, no expression

The positive cases (both `CADSiteDataCookie*` reasons with no expression still clean) stay covered by the pre-existing tests.

Worth knowing: given the current data flow, `isCADCookieNoExpression` cannot be true in production at all — the only place that sets those reasons is gated on a matched expression. It is a defensive guard whose precondition never occurs; the fix restores it to guarding nothing rather than guarding everything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LKdQqpRWqr5EQGkerng7vv