### PR TITLE
ci: run CI once per commit, drop no-op CodeQL Autobuild

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,14 +1,3 @@
-# For most projects, this workflow file will not need changing; you simply need
-# to commit it to your repository.
-#
-# You may wish to alter this file to override the set of languages analyzed,
-# or to provide custom queries or build logic.
-#
-# ******** NOTE ********
-# We have attempted to detect the languages in your repository. Please check
-# the `language` matrix defined below to confirm you have the correct set of
-# supported CodeQL languages.
-#
 name: "CodeQL"
 
 on:
@@ -20,10 +9,16 @@ on:
   schedule:
     - cron: '0 20 * * 6'
 
+# Superseded PR scans are cancelled; scans on main and the weekly scheduled scan
+# are not, because they feed the default-branch security-alert baseline.
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   CodeQL-Build:
-    # CodeQL runs on ubuntu-latest, windows-latest, and macos-latest
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     strategy:
       fail-fast: false
@@ -42,28 +37,14 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
-      # Initializes the CodeQL tools for scanning.
+      # No autobuild step: the JavaScript extractor is buildless, so
+      # codeql-action/autobuild logs "None of the languages in this project
+      # require extra build steps" and exits. Dropping it removes one more
+      # action the runner has to download during Set up job.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        # Override language selection by uncommenting this and choosing your languages
         with:
           languages: ${{ matrix.language }}
-
-      # Autobuild attempts to build any compiled languages (C/C++, C#, or Java).
-      # If this step fails, then you should remove it and run the build manually (see below).
-      - name: Autobuild
-        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-
-      # ℹ️ Command-line programs to run using the OS shell.
-      # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
-
-      # ✏️ If the Autobuild fails above, remove it and uncomment the following
-      #    three lines and modify them (or add more) to build your code if your
-      #    project uses a compiled language
-
-      #- run: |
-      #     make bootstrap
-      #     make release
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -1,9 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches-ignore:
-      - '_archived__**'
   pull_request:
     branches-ignore:
       - '_archived__**'
@@ -13,10 +10,15 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   all_jobs:
     name: Tests, Builds, Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
@@ -47,7 +49,6 @@ jobs:
         env:
           GITSHA: ${{ github.sha }}
       - name: Extract zip builds for individual artifact upload
-        if: github.event_name == 'pull_request'
         id: extbuilds
         run: |
           for i in *.zip; do echo "${i%.zip}"; done | xargs -I fn unzip fn.zip -d fn
@@ -55,13 +56,11 @@ jobs:
           echo "crdir=$(ls -d *Chrome)" >> $GITHUB_OUTPUT
         working-directory: ./builds
       - name: Upload Artifact for Mozilla Firefox Build
-        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.extbuilds.outputs.ffdir }}
           path: builds/${{ steps.extbuilds.outputs.ffdir }}
       - name: Upload Artifact for Google Chrome Build
-        if: github.event_name == 'pull_request'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ steps.extbuilds.outputs.crdir }}

--- a/.github/workflows/release-on-main.yml
+++ b/.github/workflows/release-on-main.yml
@@ -22,6 +22,7 @@ jobs:
   release:
     name: Build and Publish Release
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0


### PR DESCRIPTION
## Why

This started from CodeQL taking 15 minutes and failing, where it used to take one.

**The cause was not this repository.** githubstatus.com recorded `"Incident with Actions"`, impact **Critical**, opened `2026-08-06T15:22:49Z`: *"workflow runs failing or delayed in starting, and some queued jobs may time out."*

| Observation | Value |
|---|---|
| CodeQL job execution, 2026-08-05 baseline (run `31049224102`) | 81 s |
| CodeQL job execution, 2026-08-06 (run `31122371537`) | 80 s |
| Queue wait before that job started | 7 min 31 s |
| Failure text (run `31120552467`) | `Failed to resolve action download info. Error: Service Unavailable` |
| Step it failed at | `Set up job` — before checkout |

The analysis never got slower. The extra time was queue wait, the failure was the runner being unable to download actions, and every workflow in the repo was hit — `CI` peaked at 952 s and `Auto Release on Main` failed outright.

**Nothing in this PR fixes that incident.** It resolves on its own. What the investigation surfaced is a set of weaknesses that waste runner time every ordinary day and make the next outage hurt more than it needs to.

## What changed

### `CI` now runs once per commit, not twice

It triggered on both `push` (every branch) and `pull_request`, so every commit on a branch with an open PR built twice. **15 of the last 40 CI runs were duplicate pairs on the same SHA.** The `push` run also uploaded no artifacts, so it was pure waste, and on `main` it duplicated the test/lint/build that `release-on-main.yml` already runs before publishing.

Trigger is now `pull_request` only. The three `if: github.event_name == 'pull_request'` guards are removed, since they are now always true.

**Full test + lint + build cycles for a three-commit PR: 8 → 4.**

Cost: a branch with no open PR gets no CI. It starts the moment a PR is opened.

### CodeQL loses its `Autobuild` step

It does nothing for JavaScript. From run `31122371537`:

```
17:19:10  Run github/codeql-action/autobuild@8aad20d1...
17:19:12  None of the languages in this project require extra build steps
```

Beyond the 3 seconds, it is a third action the runner must resolve during `Set up job` — **exactly the step that failed today**. Fewer actions, smaller failure surface.

The GitHub-template header comments and the commented-out `make bootstrap` block go too; neither explains a non-obvious *why*.

### `concurrency` and `timeout-minutes`

Superseded runs are now cancelled instead of queueing ahead of the run you actually care about. CodeQL cancels **PR scans only** — scans on `main` and the weekly scheduled scan feed the default-branch security-alert baseline and must finish.

`timeout-minutes` replaces the 360-minute default: 20 for CI and CodeQL, 30 for the release job.

> **To be clear about what this does not do:** `timeout-minutes` measures execution from when a runner picks the job up, not queue time. **It would not have helped today.** It is here because a 6-hour default is poor hygiene.

## Deliberately not changed

- **`languages: javascript`** stays. The CodeQL CLI resolves `javascript-typescript` and `typescript` as aliases of it (visible in the run log), so there is nothing to migrate. No `build-mode` input either — that applies to compiled languages, and the JavaScript extractor is already buildless.
- **`paths-ignore` on CodeQL.** It would skip an 80-second scan on docs-only commits, but if required status checks are ever added, a PR that does not trigger the scan waits forever for a check that never reports. Not worth the trap.
- **`ci_tag_release.yml` and `ci_tag_testbuilds.yml`.** Neither has run since 2026-05-31. Left alone by decision.
- **When a release is cut.** `release-on-main.yml` still fires only on push to `main` and still gates publication behind its own test, lint and build. Only a timeout was added.

## Result

| | Before | After |
|---|---|---|
| test + lint + build per 3-commit PR | 8 | 4 |
| Superseded runs cancelled | none | CI and CodeQL PR scans |
| Actions downloaded per CodeQL run | 3 | 2 |
| Ceiling on a hung job | 6 h | 20–30 min |

## Verification

- `npm run test-all` on the rebased HEAD: **594 tests passed, 20 suites, lint clean (`--max-warnings 0`)**.
- All five workflow files parse as valid YAML with the intended triggers.
- **This PR is its own test case:** it should produce exactly one `CI` run, and a `CodeQL` run with no `Autobuild` step. Worth confirming in the checks below before merging.

No `ReleaseNotes.json` entry and no version bump — this is CI-only with no user-visible effect, so merging it does not cut a release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DLdSvvFpdJmG6LAttSPxg3
